### PR TITLE
Fix CLI tests after Click 7.1 release

### DIFF
--- a/tools/setup.py
+++ b/tools/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(PYTHON_SRC, 'dlpx/virtualization/_internal/VERSION')) as 
     version = version_file.read().strip()
 
 install_requires = [
-  "click >= 7.0",
+  "click >= 7.1",
   "click-configfile == 0.2.3",
   "dvp-platform == {}".format(version),
   "enum34 >= 1.1.6",

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_cli.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_cli.py
@@ -319,11 +319,11 @@ class TestBuildCli:
 
         assert result.exit_code == 2
         assert result.output == (u'Usage: delphix-sdk build [OPTIONS]'
-                                 u'\nTry "delphix-sdk build -h" for help.'
+                                 u'\nTry \'delphix-sdk build -h\' for help.'
                                  u'\n'
-                                 u'\nError: Invalid value for "-c" /'
-                                 u' "--plugin-config": File'
-                                 u' "/not/a/real/file/plugin_config.yml"'
+                                 u'\nError: Invalid value for \'-c\' /'
+                                 u' \'--plugin-config\': File'
+                                 u' \'/not/a/real/file/plugin_config.yml\''
                                  u' does not exist.'
                                  u'\n')
 
@@ -471,11 +471,11 @@ class TestUploadCli:
 
         assert result.exit_code == 2
         assert result.output == (u'Usage: delphix-sdk upload [OPTIONS]'
-                                 u'\nTry "delphix-sdk upload -h" for help.'
+                                 u'\nTry \'delphix-sdk upload -h\' for help.'
                                  u'\n'
-                                 u'\nError: Invalid value for "-a" /'
-                                 u' "--upload-artifact": File'
-                                 u' "/not/a/real/file/artifact.json"'
+                                 u'\nError: Invalid value for \'-a\' /'
+                                 u' \'--upload-artifact\': File'
+                                 u' \'/not/a/real/file/artifact.json\''
                                  u' does not exist.'
                                  u'\n')
 
@@ -538,8 +538,8 @@ class TestUploadCli:
         assert result.exit_code == 2
         assert result.output == (u'Usage: delphix-sdk upload [OPTIONS]\n'
                                  u'\n'
-                                 u'Error: Invalid value for "-e" / '
-                                 u'"--engine": Option is required '
+                                 u'Error: Invalid value for \'-e\' / '
+                                 u'\'--engine\': Option is required '
                                  u'and must be specified via the command line.'
                                  u'\n')
 
@@ -603,8 +603,8 @@ class TestDownloadCli:
         assert result.output == (
             u'Usage: delphix-sdk download-logs [OPTIONS]\n'
             u'\n'
-            u'Error: Invalid value for "-e" / '
-            u'"--engine": Option is required '
+            u'Error: Invalid value for \'-e\' / '
+            u'\'--engine\': Option is required '
             u'and must be specified via the command line.'
             u'\n')
 
@@ -656,11 +656,11 @@ class TestDownloadCli:
         assert result.exit_code == 2
         assert result.output == (
             u'Usage: delphix-sdk download-logs [OPTIONS]'
-            u'\nTry "delphix-sdk download-logs -h" for help.'
+            u'\nTry \'delphix-sdk download-logs -h\' for help.'
             u'\n'
-            u'\nError: Invalid value for "-d" /'
-            u' "--directory": Directory'
-            u' "/not/a/real/directory"'
+            u'\nError: Invalid value for \'-d\' /'
+            u' \'--directory\': Directory'
+            u' \'/not/a/real/directory\''
             u' does not exist.'
             u'\n')
 
@@ -682,11 +682,11 @@ class TestDownloadCli:
         assert result.exit_code == 2
         assert result.output == (
             u'Usage: delphix-sdk download-logs [OPTIONS]'
-            u'\nTry "delphix-sdk download-logs -h" for help.'
+            u'\nTry \'delphix-sdk download-logs -h\' for help.'
             u'\n'
-            u'\nError: Invalid value for "-c" /'
-            u' "--plugin-config": File'
-            u' "/not/a/real/file/plugin_config.yml"'
+            u'\nError: Invalid value for \'-c\' /'
+            u' \'--plugin-config\': File'
+            u' \'/not/a/real/file/plugin_config.yml\''
             u' does not exist.'
             u'\n')
 
@@ -752,7 +752,7 @@ class TestDownloadCli:
         assert result.output == (
             u'Usage: delphix-sdk download-logs [OPTIONS]\n'
             u'\n'
-            u'Error: Invalid value for "-e" / '
-            u'"--engine": Option is required '
+            u'Error: Invalid value for \'-e\' / '
+            u'\'--engine\': Option is required '
             u'and must be specified via the command line.'
             u'\n')

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_cli.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_cli.py
@@ -318,14 +318,14 @@ class TestBuildCli:
                                ['build', '-c', plugin_config_file])
 
         assert result.exit_code == 2
-        assert result.output == (u'Usage: delphix-sdk build [OPTIONS]'
-                                 u'\nTry \'delphix-sdk build -h\' for help.'
-                                 u'\n'
-                                 u'\nError: Invalid value for \'-c\' /'
-                                 u' \'--plugin-config\': File'
-                                 u' \'/not/a/real/file/plugin_config.yml\''
-                                 u' does not exist.'
-                                 u'\n')
+        assert result.output == (u"Usage: delphix-sdk build [OPTIONS]"
+                                 u"\nTry 'delphix-sdk build -h' for help."
+                                 u"\n"
+                                 u"\nError: Invalid value for '-c' /"
+                                 u" '--plugin-config': File"
+                                 u" '/not/a/real/file/plugin_config.yml'"
+                                 u" does not exist."
+                                 u"\n")
 
     @staticmethod
     def test_option_a_and_g_set(plugin_config_file, artifact_file):
@@ -470,14 +470,14 @@ class TestUploadCli:
         ])
 
         assert result.exit_code == 2
-        assert result.output == (u'Usage: delphix-sdk upload [OPTIONS]'
-                                 u'\nTry \'delphix-sdk upload -h\' for help.'
-                                 u'\n'
-                                 u'\nError: Invalid value for \'-a\' /'
-                                 u' \'--upload-artifact\': File'
-                                 u' \'/not/a/real/file/artifact.json\''
-                                 u' does not exist.'
-                                 u'\n')
+        assert result.output == (u"Usage: delphix-sdk upload [OPTIONS]"
+                                 u"\nTry 'delphix-sdk upload -h' for help."
+                                 u"\n"
+                                 u"\nError: Invalid value for '-a' /"
+                                 u" '--upload-artifact': File"
+                                 u" '/not/a/real/file/artifact.json'"
+                                 u" does not exist."
+                                 u"\n")
 
     @staticmethod
     @mock.patch('dlpx.virtualization._internal.commands.upload.upload')
@@ -601,12 +601,12 @@ class TestDownloadCli:
 
         assert result.exit_code == 2
         assert result.output == (
-            u'Usage: delphix-sdk download-logs [OPTIONS]\n'
-            u'\n'
-            u'Error: Invalid value for \'-e\' / '
-            u'\'--engine\': Option is required '
-            u'and must be specified via the command line.'
-            u'\n')
+            u"Usage: delphix-sdk download-logs [OPTIONS]\n"
+            u"\n"
+            u"Error: Invalid value for '-e' / "
+            u"'--engine': Option is required "
+            u"and must be specified via the command line."
+            u"\n")
 
     @staticmethod
     @mock.patch(
@@ -655,14 +655,14 @@ class TestDownloadCli:
 
         assert result.exit_code == 2
         assert result.output == (
-            u'Usage: delphix-sdk download-logs [OPTIONS]'
-            u'\nTry \'delphix-sdk download-logs -h\' for help.'
-            u'\n'
-            u'\nError: Invalid value for \'-d\' /'
-            u' \'--directory\': Directory'
-            u' \'/not/a/real/directory\''
-            u' does not exist.'
-            u'\n')
+            u"Usage: delphix-sdk download-logs [OPTIONS]"
+            u"\nTry 'delphix-sdk download-logs -h' for help."
+            u"\n"
+            u"\nError: Invalid value for '-d' /"
+            u" '--directory': Directory"
+            u" '/not/a/real/directory'"
+            u" does not exist."
+            u"\n")
 
     @staticmethod
     @pytest.mark.parametrize('plugin_config_file',
@@ -681,14 +681,14 @@ class TestDownloadCli:
 
         assert result.exit_code == 2
         assert result.output == (
-            u'Usage: delphix-sdk download-logs [OPTIONS]'
-            u'\nTry \'delphix-sdk download-logs -h\' for help.'
-            u'\n'
-            u'\nError: Invalid value for \'-c\' /'
-            u' \'--plugin-config\': File'
-            u' \'/not/a/real/file/plugin_config.yml\''
-            u' does not exist.'
-            u'\n')
+            u"Usage: delphix-sdk download-logs [OPTIONS]"
+            u"\nTry 'delphix-sdk download-logs -h' for help."
+            u"\n"
+            u"\nError: Invalid value for '-c' /"
+            u" '--plugin-config': File"
+            u" '/not/a/real/file/plugin_config.yml'"
+            u" does not exist."
+            u"\n")
 
     @staticmethod
     @mock.patch(
@@ -750,9 +750,9 @@ class TestDownloadCli:
 
         assert result.exit_code == 2
         assert result.output == (
-            u'Usage: delphix-sdk download-logs [OPTIONS]\n'
-            u'\n'
-            u'Error: Invalid value for \'-e\' / '
-            u'\'--engine\': Option is required '
-            u'and must be specified via the command line.'
-            u'\n')
+            u"Usage: delphix-sdk download-logs [OPTIONS]\n"
+            u"\n"
+            u"Error: Invalid value for '-e' / "
+            u"'--engine': Option is required "
+            u"and must be specified via the command line."
+            u"\n")


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

After Click 7.1 release (March 9, 2020), the CLI tests started failing with errors of this sort:
```
E         - Try 'delphix-sdk build -h' for help.
E         ?     ^                    ^
E         + Try "delphix-sdk build -h" for help.
E         ?     ^   
```
It looks like the click CLI now outputs single rather than double quotes in its error messages. This is related to [the following commit](https://github.com/pallets/click/commit/718485be48263056e7036ea9a60ce11b47e2fc26#) that did manual cleanup before the release. The commit has been shipped in versions 7.1 and 7.1.1.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Modify CLI tests to expect single rather than double quotes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
