### PR TITLE
PYT-1103 No error displayed by the dvp upload command when file upload job fails

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0-internal-001
+current_version = 2.0.0-internal-2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\-(?P<build>\d+))?

--- a/common/src/main/python/dlpx/virtualization/common/VERSION
+++ b/common/src/main/python/dlpx/virtualization/common/VERSION
@@ -1,1 +1,1 @@
-2.0.0-internal-001
+2.0.0-internal-2

--- a/dvp/src/main/python/dlpx/virtualization/VERSION
+++ b/dvp/src/main/python/dlpx/virtualization/VERSION
@@ -1,1 +1,1 @@
-2.0.0-internal-001
+2.0.0-internal-2

--- a/libs/src/main/python/dlpx/virtualization/libs/VERSION
+++ b/libs/src/main/python/dlpx/virtualization/libs/VERSION
@@ -1,1 +1,1 @@
-2.0.0-internal-001
+2.0.0-internal-2

--- a/platform/src/main/python/dlpx/virtualization/platform/VERSION
+++ b/platform/src/main/python/dlpx/virtualization/platform/VERSION
@@ -1,1 +1,1 @@
-2.0.0-internal-001
+2.0.0-internal-2

--- a/tools/src/main/python/dlpx/virtualization/_internal/VERSION
+++ b/tools/src/main/python/dlpx/virtualization/_internal/VERSION
@@ -1,1 +1,1 @@
-2.0.0-internal-001
+2.0.0-internal-2

--- a/tools/src/main/python/dlpx/virtualization/_internal/cli.py
+++ b/tools/src/main/python/dlpx/virtualization/_internal/cli.py
@@ -240,11 +240,14 @@ def build(plugin_config, upload_artifact, generate_only, skip_id_validation,
                     resolve_path=True),
     callback=click_util.validate_option_exists,
     help='Path to the upload artifact that was generated through build.')
+@click.option('--wait',
+              is_flag=True,
+              help='Wait for the upload job to complete before returning.')
 @click.password_option(cls=click_util.PasswordPromptIf,
                        default=DVP_CONFIG_MAP.get('password'),
                        confirmation_prompt=False,
                        help='Authenticate using the provided password.')
-def upload(engine, user, upload_artifact, password):
+def upload(engine, user, upload_artifact, password, wait):
     """
     Upload the generated upload artifact (the plugin JSON file) that was built
     to a target Delphix Engine.
@@ -252,7 +255,7 @@ def upload(engine, user, upload_artifact, password):
     the build command and will fail if it's not readable or valid.
     """
     with command_error_handler():
-        upload_internal.upload(engine, user, upload_artifact, password)
+        upload_internal.upload(engine, user, upload_artifact, password, wait)
 
 
 @delphix_sdk.command()

--- a/tools/src/main/python/dlpx/virtualization/_internal/commands/upload.py
+++ b/tools/src/main/python/dlpx/virtualization/_internal/commands/upload.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 UNKNOWN_ERR = 'UNKNOWN_ERR'
 
 
-def upload(engine, user, upload_artifact, password):
+def upload(engine, user, upload_artifact, password, wait):
     """
     Takes in the engine hostname/ip address, logs on and uploads the artifact
     passed in. The upload artifact should have been generated via the build
@@ -26,11 +26,14 @@ def upload(engine, user, upload_artifact, password):
         InvalidArtifactError
         HttpError
         UnexpectedError
+        PluginUploadJobFailed
+        PluginUploadWaitTimedOut
     """
     logger.debug('Upload parameters include'
                  ' engine: {},'
                  ' user: {},'
-                 ' upload_artifact: {}'.format(engine, user, upload_artifact))
+                 ' upload_artifact: {},'
+                 ' wait: {}'.format(engine, user, upload_artifact, wait))
     logger.info('Uploading plugin artifact {} ...'.format(upload_artifact))
 
     # Read content of upload artifact
@@ -54,4 +57,4 @@ def upload(engine, user, upload_artifact, password):
     client = delphix_client.DelphixClient(engine)
     engine_api = client.get_engine_api(content)
     client.login(engine_api, user, password)
-    client.upload_plugin(os.path.basename(upload_artifact), content)
+    client.upload_plugin(os.path.basename(upload_artifact), content, wait)

--- a/tools/src/main/python/dlpx/virtualization/_internal/exceptions.py
+++ b/tools/src/main/python/dlpx/virtualization/_internal/exceptions.py
@@ -36,6 +36,30 @@ class UserError(Exception):
         super(UserError, self).__init__(message)
 
 
+class PluginUploadJobFailed(UserError):
+    """
+    PluginUploadJobFailed is raised in the upload command if the action/job
+    that is being monitored returns with a status other than 'COMPLETED' or
+    'RUNNING'.
+    """
+    def __init__(self, plugin_name):
+        message = "Failed trying to upload plugin {}."\
+            .format(plugin_name)
+        super(PluginUploadJobFailed, self).__init__(message)
+
+
+class PluginUploadWaitTimedOut(UserError):
+    """
+    PluginUploadWaitTimedOut is raised in the upload command if the
+    action/job that is being monitored does not complete or fail within a
+    30 minute timeout window.
+    """
+    def __init__(self, plugin):
+        message = "Timed out waiting for upload of plugin {} to complete."\
+            .format(plugin)
+        super(PluginUploadWaitTimedOut, self).__init__(message)
+
+
 class PathIsAbsoluteError(UserError):
     def __init__(self, path):
         self.path = path

--- a/tools/src/test/python/dlpx/virtualization/_internal/commands/test_build.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/commands/test_build.py
@@ -66,9 +66,9 @@ class TestBuild:
         'dlpx.virtualization._internal.plugin_dependency_util.install_deps')
     @mock.patch('os.path.isabs', return_value=False)
     def test_build_success_non_default_output_file(
-        mock_relative_path, mock_install_deps, mock_generate_python,
-        mock_import_plugin, plugin_config_file, artifact_file,
-        artifact_content, codegen_gen_py_inputs):
+            mock_relative_path, mock_install_deps, mock_generate_python,
+            mock_import_plugin, plugin_config_file, artifact_file,
+            artifact_content, codegen_gen_py_inputs):
         gen_py = codegen_gen_py_inputs
 
         # Before running build assert that the artifact file does not exist.
@@ -217,9 +217,9 @@ class TestBuild:
         'dlpx.virtualization._internal.plugin_dependency_util.install_deps')
     @mock.patch('os.path.isabs', return_value=False)
     def test_build_generate_artifact_fail(
-        mock_relative_path, mock_install_deps, mock_generate_python,
-        mock_plugin_manifest, mock_gen_artifact, plugin_config_file,
-        artifact_file, codegen_gen_py_inputs):
+            mock_relative_path, mock_install_deps, mock_generate_python,
+            mock_plugin_manifest, mock_gen_artifact, plugin_config_file,
+            artifact_file, codegen_gen_py_inputs):
         gen_py = codegen_gen_py_inputs
 
         # Before running build assert that the artifact file does not exist.
@@ -320,8 +320,7 @@ class TestBuild:
 
     @staticmethod
     @mock.patch('compileall.compile_dir')
-    def test_zip_and_encode_source_files_compileall_fail(
-        mock_compile, src_dir):
+    def test_zip_and_encode_source_files_compileall_fail(mock_compile, src_dir):
         mock_compile.return_value = 0
         with pytest.raises(exceptions.UserError) as err_info:
             build.zip_and_encode_source_files(src_dir)

--- a/tools/src/test/python/dlpx/virtualization/_internal/commands/test_delphix_client.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/commands/test_delphix_client.py
@@ -222,6 +222,30 @@ class TestDelphixClient:
             'Date': 'Mon, 04 Feb 2019 08:09:44 GMT'
         })
 
+    JOB_RESP_FAIL = (('{"type": "OKResult", "status": "OK", "result": '
+                      '{"jobState": "FAILED", "events": []}}'), {
+                         'X-Frame-Options': 'SAMEORIGIN',
+                         'X-Content-Type-Options': 'nosniff',
+                         'X-XSS-Protection': '1; mode=block',
+                         'Cache-Control': 'max-age=0',
+                         'Expires': 'Mon, 04 Feb 2019 23:12:00 GMT',
+                         'Content-Type': 'application/json',
+                         'Content-Length': '71',
+                         'Date': 'Mon, 09 Mar 2020 12:09:27 GMT'
+                     })
+
+    JOB_RESP_TIMED_OUT = (('{"type": "OKResult", "status": "OK", "result": '
+                           '{"jobState": "RUNNING", "events": []}}'), {
+                              'X-Frame-Options': 'SAMEORIGIN',
+                              'X-Content-Type-Options': 'nosniff',
+                              'X-XSS-Protection': '1; mode=block',
+                              'Cache-Control': 'max-age=0',
+                              'Expires': 'Mon, 04 Feb 2019 23:12:00 GMT',
+                              'Content-Type': 'application/json',
+                              'Content-Length': '71',
+                              'Date': 'Mon, 09 Mar 2020 12:09:27 GMT'
+                          })
+
     PLUGIN_RESP_SUCCESS = (
         '{"type": "ListResult", "status": "OK", "result": ['
         '{"type": "Toolkit", "reference": "APPDATA_TOOLKIT-1",'
@@ -289,7 +313,7 @@ class TestDelphixClient:
 
         dc = delphix_client.DelphixClient('test-engine.com')
         dc.login(engine_api, 'admin', 'delphix')
-        dc.upload_plugin('plugin name', artifact_content)
+        dc.upload_plugin('plugin name', artifact_content, False)
 
         history = httpretty.HTTPretty.latest_requests
         assert history[-1].path == u'/resources/json/delphix/data/upload'
@@ -490,7 +514,7 @@ class TestDelphixClient:
         dc.login(engine_api, 'admin', 'delphix')
 
         with pytest.raises(exceptions.UnexpectedError) as err_info:
-            dc.upload_plugin('plugin name', artifact_content)
+            dc.upload_plugin('plugin name', artifact_content, False)
 
         assert err_info.value.status_code == 403
         assert err_info.value.response == token_body
@@ -538,7 +562,7 @@ class TestDelphixClient:
         dc.login(engine_api, 'admin', 'delphix')
 
         with pytest.raises(exceptions.HttpError) as err_info:
-            dc.upload_plugin('plugin name', artifact_content)
+            dc.upload_plugin('plugin name', artifact_content, False)
         error = err_info.value.error
         message = err_info.value.message
         assert err_info.value.status_code == 200
@@ -565,6 +589,99 @@ class TestDelphixClient:
                 u'/resources/json/delphix/toolkit/requestUploadToken')
         assert history[-3].path == u'/resources/json/delphix/login'
         assert history[-4].path == u'/resources/json/delphix/session'
+
+    @staticmethod
+    def test_delphix_client_wait_for_job_to_complete_job_failed(
+            engine_api, artifact_content):
+        session_body, session_header = TestDelphixClient.SES_RESP_SUCCESS
+        httpretty.register_uri(
+            httpretty.POST,
+            'http://test-engine.com/resources/json/delphix/session',
+            body=session_body,
+            forcing_headers=session_header)
+
+        login_body, login_header = TestDelphixClient.LOGIN_RESP_SUCCESS
+        httpretty.register_uri(
+            httpretty.POST,
+            'http://test-engine.com/resources/json/delphix/login',
+            body=login_body,
+            forcing_headers=login_header)
+
+        token_body, token_header = TestDelphixClient.TOKEN_RESP_SUCCESS
+        httpretty.register_uri(httpretty.POST,
+                               'http://test-engine.com/resources/'
+                               'json/delphix/toolkit/requestUploadToken',
+                               body=token_body,
+                               forcing_headers=token_header)
+
+        job_body, job_header = TestDelphixClient.JOB_RESP_FAIL
+        httpretty.register_uri(httpretty.GET,
+                               'http://test-engine.com/resources/json/'
+                               'delphix/action/ACTION-161/getJob',
+                               body=job_body)
+
+        dc = delphix_client.DelphixClient('test-engine.com')
+        dc.login(engine_api, 'admin', 'delphix')
+
+        with pytest.raises(exceptions.PluginUploadJobFailed) as err_info:
+            dc._wait_for_upload_to_complete('nix_direct_python', 'ACTION-161',
+                                            'JOB-38')
+
+        assert err_info.value.message == ('Failed trying to upload plugin '
+                                          'nix_direct_python.')
+
+        history = httpretty.HTTPretty.latest_requests
+        assert (history[-1].path ==
+                u'/resources/json/delphix/action/ACTION-161/getJob')
+        assert history[-2].path == u'/resources/json/delphix/login'
+        assert history[-3].path == u'/resources/json/delphix/session'
+
+    @staticmethod
+    def test_delphix_client_wait_for_job_to_complete_timed_out(
+            engine_api, artifact_content):
+        session_body, session_header = TestDelphixClient.SES_RESP_SUCCESS
+        httpretty.register_uri(
+            httpretty.POST,
+            'http://test-engine.com/resources/json/delphix/session',
+            body=session_body,
+            forcing_headers=session_header)
+
+        login_body, login_header = TestDelphixClient.LOGIN_RESP_SUCCESS
+        httpretty.register_uri(
+            httpretty.POST,
+            'http://test-engine.com/resources/json/delphix/login',
+            body=login_body,
+            forcing_headers=login_header)
+
+        token_body, token_header = TestDelphixClient.TOKEN_RESP_SUCCESS
+        httpretty.register_uri(httpretty.POST,
+                               'http://test-engine.com/resources/'
+                               'json/delphix/toolkit/requestUploadToken',
+                               body=token_body,
+                               forcing_headers=token_header)
+
+        job_body, job_header = TestDelphixClient.JOB_RESP_TIMED_OUT
+        httpretty.register_uri(httpretty.GET,
+                               'http://test-engine.com/resources/json/'
+                               'delphix/action/ACTION-161/getJob',
+                               body=job_body)
+
+        dc = delphix_client.DelphixClient('test-engine.com', 0)
+        dc.login(engine_api, 'admin', 'delphix')
+
+        with pytest.raises(exceptions.PluginUploadWaitTimedOut) as err_info:
+            dc._wait_for_upload_to_complete('nix_direct_python', 'ACTION-161',
+                                            'JOB-38')
+
+        assert err_info.value.message == ('Timed out waiting for upload of '
+                                          'plugin nix_direct_python to '
+                                          'complete.')
+
+        history = httpretty.HTTPretty.latest_requests
+        assert (history[-1].path ==
+                u'/resources/json/delphix/action/ACTION-161/getJob')
+        assert history[-2].path == u'/resources/json/delphix/login'
+        assert history[-3].path == u'/resources/json/delphix/session'
 
     @staticmethod
     def test_delphix_client_download_success(engine_api, src_dir,

--- a/tools/src/test/python/dlpx/virtualization/_internal/commands/test_upload.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/commands/test_upload.py
@@ -61,7 +61,7 @@ class FakeDelphixClient(object):
                     'id': 'exception.webservices.login.failed'
                 })
 
-    def upload_plugin(self, name, content):
+    def upload_plugin(self, name, content, wait):
         if content.get('discoveryDefinition') is None:
             raise exceptions.HttpError(
                 200, {
@@ -113,7 +113,7 @@ class TestUpload:
         user = 'admin'
         password = 'delphix'
 
-        upload.upload(fake_client.engine, user, artifact_file, password)
+        upload.upload(fake_client.engine, user, artifact_file, password, False)
 
         # Make sure that the fake client was passed in the correct contents.
         assert (
@@ -128,7 +128,8 @@ class TestUpload:
         password = 'delphix'
 
         with pytest.raises(exceptions.UserError) as err_info:
-            upload.upload(fake_client.engine, user, artifact_file, password)
+            upload.upload(fake_client.engine, user, artifact_file, password,
+                          False)
 
         message = err_info.value.message
         assert message == ("Unable to read upload artifact file"
@@ -148,7 +149,8 @@ class TestUpload:
         password = 'delphix'
 
         with pytest.raises(exceptions.UserError) as err_info:
-            upload.upload(fake_client.engine, user, artifact_file, password)
+            upload.upload(fake_client.engine, user, artifact_file, password,
+                          False)
 
         message = err_info.value.message
         assert message == (
@@ -172,7 +174,8 @@ class TestUpload:
         password = 'delphix'
 
         with pytest.raises(exceptions.HttpError) as err_info:
-            upload.upload(fake_client.engine, user, artifact_file, password)
+            upload.upload(fake_client.engine, user, artifact_file, password,
+                          False)
 
         error = err_info.value.error
         message = err_info.value.message
@@ -203,7 +206,8 @@ class TestUpload:
         password = 'delphix2'
 
         with pytest.raises(exceptions.HttpError) as err_info:
-            upload.upload(fake_client.engine, user, artifact_file, password)
+            upload.upload(fake_client.engine, user, artifact_file, password,
+                          False)
 
         error = err_info.value.error
         message = err_info.value.message
@@ -228,7 +232,8 @@ class TestUpload:
         password = 'delphix'
 
         with pytest.raises(exceptions.HttpError) as err_info:
-            upload.upload(fake_client.engine, user, artifact_file, password)
+            upload.upload(fake_client.engine, user, artifact_file, password,
+                          False)
 
         error = err_info.value.error
         message = err_info.value.message

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_cli.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_cli.py
@@ -406,7 +406,7 @@ class TestUploadCli:
 
         assert result.exit_code == 0, 'Output: {}'.format(result.output)
         mock_upload.assert_called_once_with(engine, user, artifact_file,
-                                            password)
+                                            password, False)
 
     @staticmethod
     @mock.patch('dlpx.virtualization._internal.commands.upload.upload')
@@ -423,7 +423,7 @@ class TestUploadCli:
 
         assert result.exit_code == 0, 'Output: {}'.format(result.output)
         mock_upload.assert_called_once_with(engine, user, artifact_file,
-                                            password)
+                                            password, False)
 
     @staticmethod
     @mock.patch('dlpx.virtualization._internal.commands.upload.upload')
@@ -452,7 +452,7 @@ class TestUploadCli:
             '\nAction: Try with a different set of credentials.'
             '\n')
         mock_upload.assert_called_once_with(engine, user, artifact_file,
-                                            password)
+                                            password, False)
 
     @staticmethod
     @pytest.mark.parametrize('artifact_file',
@@ -497,7 +497,7 @@ class TestUploadCli:
 
         assert result.exit_code == 0, 'Output: {}'.format(result.output)
         mock_upload.assert_called_once_with(engine, user, artifact_file,
-                                            password)
+                                            password, False)
 
     @staticmethod
     @mock.patch('dlpx.virtualization._internal.commands.upload.upload')
@@ -517,7 +517,7 @@ class TestUploadCli:
 
         assert result.exit_code == 0, 'Output: {}'.format(result.output)
         mock_upload.assert_called_once_with(engine, user, artifact_file,
-                                            password)
+                                            password, False)
 
     @staticmethod
     @pytest.mark.parametrize('dvp_config_properties', [{

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_package_util.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_package_util.py
@@ -10,7 +10,7 @@ import pytest
 class TestPackageUtil:
     @staticmethod
     def test_get_version():
-        assert package_util.get_version() == '2.0.0-internal-001'
+        assert package_util.get_version() == '2.0.0-internal-2'
 
     @staticmethod
     def test_get_virtualization_api_version():

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_plugin_importer.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_plugin_importer.py
@@ -15,7 +15,6 @@ import pytest
 import yaml
 
 
-
 @pytest.fixture
 def fake_src_dir(plugin_type):
     """


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The dvp upload command issues an upload job to a Delphix Engine but does not wait for the upload to complete before returning. This can be problematic for both testing and end-users since we can't tell whether the upload job finished successfully or not.

## What is the new behavior?
Introduce a wait flag in the dvp upload command that waits for the upload job to complete. We query the upload action and job every 5 seconds until the job succeeds, fails, or times out (60 min).

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
