### PR TITLE
PYT-868 Lua to Python - Change plugin config to expect optional lua name

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0-internal-2
+current_version = 2.1.0-internal-0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\-(?P<build>\d+))?

--- a/common/src/main/python/dlpx/virtualization/common/VERSION
+++ b/common/src/main/python/dlpx/virtualization/common/VERSION
@@ -1,1 +1,1 @@
-2.0.0-internal-2
+2.1.0-internal-0

--- a/dvp/src/main/python/dlpx/virtualization/VERSION
+++ b/dvp/src/main/python/dlpx/virtualization/VERSION
@@ -1,1 +1,1 @@
-2.0.0-internal-2
+2.1.0-internal-0

--- a/libs/src/main/python/dlpx/virtualization/libs/VERSION
+++ b/libs/src/main/python/dlpx/virtualization/libs/VERSION
@@ -1,1 +1,1 @@
-2.0.0-internal-2
+2.1.0-internal-0

--- a/platform/src/main/python/dlpx/virtualization/platform/VERSION
+++ b/platform/src/main/python/dlpx/virtualization/platform/VERSION
@@ -1,1 +1,1 @@
-2.0.0-internal-2
+2.1.0-internal-0

--- a/tools/src/main/python/dlpx/virtualization/_internal/VERSION
+++ b/tools/src/main/python/dlpx/virtualization/_internal/VERSION
@@ -1,1 +1,1 @@
-2.0.0-internal-2
+2.1.0-internal-0

--- a/tools/src/main/python/dlpx/virtualization/_internal/commands/build.py
+++ b/tools/src/main/python/dlpx/virtualization/_internal/commands/build.py
@@ -214,6 +214,9 @@ def prepare_upload_artifact(plugin_config_content, src_dir, schemas, manifest):
     if plugin_config_content.get('externalVersion'):
         artifact['externalVersion'] = plugin_config_content['externalVersion']
 
+    if plugin_config_content.get('luaName'):
+        artifact['luaName'] = plugin_config_content['luaName']
+
     return artifact
 
 

--- a/tools/src/main/python/dlpx/virtualization/_internal/validation_schemas/plugin_config_schema.json
+++ b/tools/src/main/python/dlpx/virtualization/_internal/validation_schemas/plugin_config_schema.json
@@ -50,6 +50,10 @@
       "buildNumber":  {
           "type": "string",
           "pattern": "^([0-9]+\\.)*[0-9]*[1-9][0-9]*(\\.[0-9]+)*$"
+      },
+      "luaName":  {
+          "type": "string",
+          "pattern": "^[a-z0-9_:-]+$"
       }
     },
     "additionalProperties": false,

--- a/tools/src/main/python/dlpx/virtualization/_internal/validation_schemas/plugin_config_schema_no_id_validation.json
+++ b/tools/src/main/python/dlpx/virtualization/_internal/validation_schemas/plugin_config_schema_no_id_validation.json
@@ -49,6 +49,10 @@
       "buildNumber":  {
           "type": "string",
           "pattern": "^([0-9]+\\.)*[0-9]*[1-9][0-9]*(\\.[0-9]+)*$"
+      },
+      "luaName":  {
+          "type": "string",
+          "pattern": "^[a-z0-9_:-]+$"
       }
     },
     "additionalProperties": false,

--- a/tools/src/test/python/dlpx/virtualization/_internal/commands/test_build.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/commands/test_build.py
@@ -651,3 +651,14 @@ class TestPluginUtil:
             plugin_config_content, src_dir, schema_content, {})
 
         assert expected == upload_artifact['buildNumber']
+
+    @staticmethod
+    @pytest.mark.parametrize('lua_name, expected', [
+        pytest.param('lua-toolkit-1', 'lua-toolkit-1'),
+        pytest.param(None, None)
+    ])
+    def test_lua_name_parameter(plugin_config_content, src_dir,
+                                schema_content, expected):
+        upload_artifact = build.prepare_upload_artifact(
+            plugin_config_content, src_dir, schema_content, {})
+        assert expected == upload_artifact.get('luaName')

--- a/tools/src/test/python/dlpx/virtualization/_internal/conftest.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/conftest.py
@@ -171,7 +171,7 @@ def artifact_file_created():
 @pytest.fixture
 def plugin_config_content(plugin_id, plugin_name, external_version, language,
                           host_types, plugin_type, entry_point, src_dir,
-                          schema_file, manual_discovery, build_number):
+                          schema_file, manual_discovery, build_number, lua_name):
     """
     This fixutre creates the dict expected in the properties yaml file the
     customer must provide for the build and compile commands.
@@ -215,6 +215,9 @@ def plugin_config_content(plugin_id, plugin_name, external_version, language,
 
     if build_number:
         config['buildNumber'] = build_number
+
+    if lua_name:
+        config['luaName'] = lua_name
 
     return config
 
@@ -272,6 +275,11 @@ def manual_discovery():
 @pytest.fixture
 def build_number():
     return '2.0.0'
+
+
+@pytest.fixture
+def lua_name():
+    return 'lua-toolkit-1'
 
 
 @pytest.fixture
@@ -561,6 +569,7 @@ def basic_artifact_content(engine_api, virtual_source_definition,
         'engineApi': engine_api,
         'rootSquashEnabled': True,
         'buildNumber': '2',
+        'luaName': 'lua-toolkit-1',
         'sourceCode': 'UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA==',
         'manifest': {}
     }
@@ -608,6 +617,7 @@ def artifact_content(engine_api, virtual_source_definition,
         'sourceCode': 'UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA==',
         'rootSquashEnabled': True,
         'buildNumber': '2',
+        'luaName': 'lua-toolkit-1',
         'manifest': {}
     }
 

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_package_util.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_package_util.py
@@ -10,7 +10,7 @@ import pytest
 class TestPackageUtil:
     @staticmethod
     def test_get_version():
-        assert package_util.get_version() == '2.0.0-internal-2'
+        assert package_util.get_version() == '2.1.0-internal-0'
 
     @staticmethod
     def test_get_virtualization_api_version():

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_plugin_validator.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_plugin_validator.py
@@ -171,3 +171,21 @@ class TestPluginValidator:
         except exceptions.SchemaValidationError as err_info:
             message = err_info.message
             assert expected in message
+
+    @staticmethod
+    @mock.patch('os.path.isabs', return_value=False)
+    @pytest.mark.parametrize('lua_name, expected', [
+        ('lua toolkit', "'lua toolkit' does not match"),
+        ('!lua#toolkit', "'!lua#toolkit' does not match"),
+        (None, "should never get here")
+    ])
+    def test_plugin_lua_name_format(src_dir, plugin_config_file,
+                                    plugin_config_content, expected):
+        try:
+            validator = PluginValidator.from_config_content(
+                plugin_config_file, plugin_config_content,
+                const.PLUGIN_CONFIG_SCHEMA)
+            validator.validate_plugin_config()
+        except exceptions.SchemaValidationError as err_info:
+            message = err_info.message
+            assert expected in message


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [x] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
dvp build will not expect a luaName field in the plugin config


## What is the new behavior?
dvp build will add the luaName property into the upload artifact if it exists

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
