### PR TITLE
Fix linting and formatting issues in the tools package

### DIFF
--- a/tools/src/test/python/dlpx/virtualization/_internal/commands/test_build.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/commands/test_build.py
@@ -320,7 +320,8 @@ class TestBuild:
 
     @staticmethod
     @mock.patch('compileall.compile_dir')
-    def test_zip_and_encode_source_files_compileall_fail(mock_compile, src_dir):
+    def test_zip_and_encode_source_files_compileall_fail(
+            mock_compile, src_dir):
         mock_compile.return_value = 0
         with pytest.raises(exceptions.UserError) as err_info:
             build.zip_and_encode_source_files(src_dir)
@@ -442,7 +443,7 @@ class TestPluginUtil:
 
         message = err_info.value.message
         assert message == "The path '{}' does not exist.".format(
-	    tmpdir.join(os.path.join('fake', 'dir')).strpath)
+            tmpdir.join(os.path.join('fake', 'dir')).strpath)
 
         assert not mock_generate_python.called
 
@@ -501,12 +502,14 @@ class TestPluginUtil:
                                         schema_file):
         # Make it so we can't read the file
         if os.name == 'nt':
-	    pytest.skip('skipping this test on windows as os.chmod has issues removing permissions on file')
-	    #
-	    # The schema_file can be made unreadable on windows using pypiwin32 but
-	    # since it adds dependency on pypiwin32 for the sdk, skipping this test
-	    # instead of potentially destabilizing the sdk by adding this dependency.
-	    #
+            pytest.skip(
+                'skipping this test on windows as os.chmod has issues removing'
+                ' permissions on file')
+            #
+            # The schema_file can be made unreadable on windows using pypiwin32 but
+            # since it adds dependency on pypiwin32 for the sdk, skipping this test
+            # instead of potentially destabilizing the sdk by adding this dependency.
+            #
         else:
             os.chmod(schema_file, 0000)
         with pytest.raises(exceptions.UserError) as err_info:
@@ -666,8 +669,8 @@ class TestPluginUtil:
         pytest.param('lua-toolkit-1', 'lua-toolkit-1'),
         pytest.param(None, None)
     ])
-    def test_lua_name_parameter(plugin_config_content, src_dir,
-                                schema_content, expected):
+    def test_lua_name_parameter(plugin_config_content, src_dir, schema_content,
+                                expected):
         upload_artifact = build.prepare_upload_artifact(
             plugin_config_content, src_dir, schema_content, {})
         assert expected == upload_artifact.get('luaName')

--- a/tools/src/test/python/dlpx/virtualization/_internal/commands/test_codegen.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/commands/test_codegen.py
@@ -371,7 +371,8 @@ class TestCodegen:
             codegen._copy_generated_to_dir(src_dir, dst_dir)
 
         if os.name == 'nt':
-            assert err_info.value.strerror == 'The system cannot find the path specified'
+            assert err_info.value.strerror == 'The system cannot find the path' \
+                                              ' specified'
         else:
             assert err_info.value.strerror == 'No such file or directory'
 

--- a/tools/src/test/python/dlpx/virtualization/_internal/commands/test_delphix_client.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/commands/test_delphix_client.py
@@ -224,27 +224,27 @@ class TestDelphixClient:
 
     JOB_RESP_FAIL = (('{"type": "OKResult", "status": "OK", "result": '
                       '{"jobState": "FAILED", "events": []}}'), {
-                         'X-Frame-Options': 'SAMEORIGIN',
-                         'X-Content-Type-Options': 'nosniff',
-                         'X-XSS-Protection': '1; mode=block',
-                         'Cache-Control': 'max-age=0',
-                         'Expires': 'Mon, 04 Feb 2019 23:12:00 GMT',
-                         'Content-Type': 'application/json',
-                         'Content-Length': '71',
-                         'Date': 'Mon, 09 Mar 2020 12:09:27 GMT'
-                     })
+                          'X-Frame-Options': 'SAMEORIGIN',
+                          'X-Content-Type-Options': 'nosniff',
+                          'X-XSS-Protection': '1; mode=block',
+                          'Cache-Control': 'max-age=0',
+                          'Expires': 'Mon, 04 Feb 2019 23:12:00 GMT',
+                          'Content-Type': 'application/json',
+                          'Content-Length': '71',
+                          'Date': 'Mon, 09 Mar 2020 12:09:27 GMT'
+                      })
 
     JOB_RESP_TIMED_OUT = (('{"type": "OKResult", "status": "OK", "result": '
                            '{"jobState": "RUNNING", "events": []}}'), {
-                              'X-Frame-Options': 'SAMEORIGIN',
-                              'X-Content-Type-Options': 'nosniff',
-                              'X-XSS-Protection': '1; mode=block',
-                              'Cache-Control': 'max-age=0',
-                              'Expires': 'Mon, 04 Feb 2019 23:12:00 GMT',
-                              'Content-Type': 'application/json',
-                              'Content-Length': '71',
-                              'Date': 'Mon, 09 Mar 2020 12:09:27 GMT'
-                          })
+                               'X-Frame-Options': 'SAMEORIGIN',
+                               'X-Content-Type-Options': 'nosniff',
+                               'X-XSS-Protection': '1; mode=block',
+                               'Cache-Control': 'max-age=0',
+                               'Expires': 'Mon, 04 Feb 2019 23:12:00 GMT',
+                               'Content-Type': 'application/json',
+                               'Content-Length': '71',
+                               'Date': 'Mon, 09 Mar 2020 12:09:27 GMT'
+                           })
 
     PLUGIN_RESP_SUCCESS = (
         '{"type": "ListResult", "status": "OK", "result": ['

--- a/tools/src/test/python/dlpx/virtualization/_internal/conftest.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/conftest.py
@@ -171,7 +171,8 @@ def artifact_file_created():
 @pytest.fixture
 def plugin_config_content(plugin_id, plugin_name, external_version, language,
                           host_types, plugin_type, entry_point, src_dir,
-                          schema_file, manual_discovery, build_number, lua_name):
+                          schema_file, manual_discovery, build_number,
+                          lua_name):
     """
     This fixutre creates the dict expected in the properties yaml file the
     customer must provide for the build and compile commands.

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_file_util.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_file_util.py
@@ -35,8 +35,8 @@ class TestFileUtil:
         cwd = os.getcwd()
         try:
             os.chdir(str(tmp_path))
-            actual = file_util.get_src_dir_path(os.path.join('plugin', 'plugin_config.yml'),
-                                                'src')
+            actual = file_util.get_src_dir_path(
+                os.path.join('plugin', 'plugin_config.yml'), 'src')
         finally:
             os.chdir(cwd)
 
@@ -78,15 +78,16 @@ class TestFileUtil:
     @mock.patch('os.path.isdir', return_value=True)
     @mock.patch('os.path.exists', return_value=True)
     @mock.patch('os.path.isabs', return_value=False)
-    @pytest.mark.parametrize(
-        'plugin_config_file_path, src_dir_path',
-        [('plugin/file_name', '.'),
-         ('/mongo/file_name', '/src'), ('/plugin/mongo/file_name', '/plugin'),
-         ('/plugin/file_name', '/plugin/src/../..')])
+    @pytest.mark.parametrize('plugin_config_file_path, src_dir_path',
+                             [('plugin/file_name', '.'),
+                              ('/mongo/file_name', '/src'),
+                              ('/plugin/mongo/file_name', '/plugin'),
+                              ('/plugin/file_name', '/plugin/src/../..')])
     def test_get_src_dir_path_fail(mock_relative_path, mock_existing_path,
                                    mock_directory_path,
                                    plugin_config_file_path, src_dir_path):
-        expected_plugin_root_dir = os.path.join(os.getcwd(), os.path.dirname(plugin_config_file_path))
+        expected_plugin_root_dir = os.path.join(
+            os.getcwd(), os.path.dirname(plugin_config_file_path))
 
         expected_plugin_root_dir = file_util.standardize_path(
             expected_plugin_root_dir)

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_plugin_dependency_util.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_plugin_dependency_util.py
@@ -61,8 +61,7 @@ class TestPluginDependencyUtil:
         mock_build_wheel.side_effect = build_wheel
 
         pdu.install_deps(str(build_dir), local_vsdk_root='vsdk')
-        mock_install_to_dir.assert_called_once_with(packages,
-                                                    str(build_dir))
+        mock_install_to_dir.assert_called_once_with(packages, str(build_dir))
 
     @staticmethod
     @mock.patch.object(subprocess, 'Popen')

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_plugin_importer.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_plugin_importer.py
@@ -44,23 +44,22 @@ class TestPluginImporter:
     """
     This class tests the plugin_importer module of sdk. Though some of these tests
     used mock initially to mock out the calls to subprocess, it was found
-    that the behaviour is different between windows and linux causing these tests 
+    that the behaviour is different between windows and linux causing these tests
     to fail on windows. So, some refactoring is done in plugin_importer
     to facilitate testing without the mocks.
-    
-    The issue is described in detail here : 
+
+    The issue is described in detail here:
     https://rhodesmill.org/brandon/2010/python-multiprocessing-linux-windows/
     """
     @staticmethod
-    def test_get_plugin_manifest(src_dir, plugin_type,
-                                 entry_point_module, entry_point_object,
-                                 plugin_module_content, plugin_manifest):
+    def test_get_plugin_manifest(src_dir, plugin_type, entry_point_module,
+                                 entry_point_object, plugin_module_content,
+                                 plugin_manifest):
         queue = Queue()
         manifest = plugin_importer.get_manifest(src_dir, entry_point_module,
                                                 entry_point_object,
                                                 plugin_module_content,
-                                                plugin_type,
-                                                False, queue)
+                                                plugin_type, False, queue)
 
         assert manifest == plugin_manifest
 
@@ -70,54 +69,45 @@ class TestPluginImporter:
                                         entry_point_object):
         queue = Queue()
         manifest = plugin_importer.get_manifest(src_dir, entry_point_module,
-                                                entry_point_object,
-                                                None,
-                                                plugin_type,
-                                                False, queue)
+                                                entry_point_object, None,
+                                                plugin_type, False, queue)
         assert manifest is None
 
     @staticmethod
-    def test_plugin_entry_object_none(src_dir, plugin_type,
-                                      entry_point_module, plugin_module_content):
+    def test_plugin_entry_object_none(src_dir, plugin_type, entry_point_module,
+                                      plugin_module_content):
         queue = Queue()
-        manifest = plugin_importer.get_manifest(src_dir, entry_point_module,
-                                                None,
-                                                plugin_module_content,
-                                                plugin_type,
-                                                False, queue)
+        plugin_importer.get_manifest(src_dir, entry_point_module, None,
+                                     plugin_module_content, plugin_type, False,
+                                     queue)
 
         message = str(queue.get('exception'))
         assert 'Plugin entry point object is None.' in message
 
     @staticmethod
     def test_plugin_entry_point_nonexistent(src_dir, plugin_type,
-                                            entry_point_module,
-                                            plugin_name,
+                                            entry_point_module, plugin_name,
                                             plugin_module_content):
         entry_point_name = "nonexistent entry point"
         queue = Queue()
-        manifest = plugin_importer.get_manifest(src_dir, entry_point_module,
-                                                entry_point_name,
-                                                plugin_module_content,
-                                                plugin_type,
-                                                False, queue)
+        plugin_importer.get_manifest(src_dir, entry_point_module,
+                                     entry_point_name, plugin_module_content,
+                                     plugin_type, False, queue)
 
         message = str(queue.get('exception'))
-        assert ("'{}' is not a symbol in module".format(entry_point_name) in
-                message)
+        assert ("'{}' is not a symbol in module".format(entry_point_name)
+                in message)
 
     @staticmethod
-    def test_plugin_object_none(src_dir, plugin_type, entry_point_module, plugin_name,
-                                plugin_module_content):
+    def test_plugin_object_none(src_dir, plugin_type, entry_point_module,
+                                plugin_name, plugin_module_content):
         none_entry_point = "none_entry_point"
         setattr(plugin_module_content, none_entry_point, None)
 
         queue = Queue()
-        manifest = plugin_importer.get_manifest(src_dir, entry_point_module,
-                                                none_entry_point,
-                                                plugin_module_content,
-                                                plugin_type,
-                                                False, queue)
+        plugin_importer.get_manifest(src_dir, entry_point_module,
+                                     none_entry_point, plugin_module_content,
+                                     plugin_type, False, queue)
 
         message = str(queue.get('exception'))
         assert ('Plugin object retrieved from the entry point {} is'

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_plugin_validator.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_plugin_validator.py
@@ -174,11 +174,11 @@ class TestPluginValidator:
 
     @staticmethod
     @mock.patch('os.path.isabs', return_value=False)
-    @pytest.mark.parametrize('lua_name, expected', [
-        ('lua toolkit', "'lua toolkit' does not match"),
-        ('!lua#toolkit', "'!lua#toolkit' does not match"),
-        (None, "should never get here")
-    ])
+    @pytest.mark.parametrize(
+        'lua_name, expected',
+        [('lua toolkit', "'lua toolkit' does not match"),
+         ('!lua#toolkit', "'!lua#toolkit' does not match"),
+         (None, "should never get here")])
     def test_plugin_lua_name_format(src_dir, plugin_config_file,
                                     plugin_config_content, expected):
         try:

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_schema_validator.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_schema_validator.py
@@ -354,5 +354,5 @@ class TestSchemaValidator:
             validator.validate()
 
         message = err_info.value.message
-        assert (
-            "'strings' is not valid under any of the given schemas" in message)
+        assert ("'strings' is not valid under any of the given schemas"
+                in message)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and any changes were pushed
- [x] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

The linter GitHub action started failing with the following errors:
```Run python -m flake8 src/test/python --max-line-length 88
src/test/python/dlpx/virtualization/_internal/test_file_util.py:38:89: E501 line too long (92 > 88 characters)
src/test/python/dlpx/virtualization/_internal/test_file_util.py:89:89: E501 line too long (102 > 88 characters)
src/test/python/dlpx/virtualization/_internal/test_plugin_importer.py:47:82: W291 trailing whitespace
src/test/python/dlpx/virtualization/_internal/test_plugin_importer.py:50:1: W293 blank line contains whitespace
src/test/python/dlpx/virtualization/_internal/test_plugin_importer.py:51:44: W291 trailing whitespace
src/test/python/dlpx/virtualization/_internal/test_plugin_importer.py:83:9: F841 local variable 'manifest' is assigned to but never used
src/test/python/dlpx/virtualization/_internal/test_plugin_importer.py:99:9: F841 local variable 'manifest' is assigned to but never used
src/test/python/dlpx/virtualization/_internal/test_plugin_importer.py:116:9: F841 local variable 'manifest' is assigned to but never used
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:445:1: E101 indentation contains mixed spaces and tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:445:1: W191 indentation contains tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:504:1: E101 indentation contains mixed spaces and tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:504:1: W191 indentation contains tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:504:89: E501 line too long (101 > 88 characters)
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:505:1: E101 indentation contains mixed spaces and tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:505:1: W191 indentation contains tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:506:1: E101 indentation contains mixed spaces and tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:506:1: W191 indentation contains tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:507:1: E101 indentation contains mixed spaces and tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:507:1: W191 indentation contains tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:508:1: E101 indentation contains mixed spaces and tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:508:1: W191 indentation contains tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:509:1: E101 indentation contains mixed spaces and tabs
src/test/python/dlpx/virtualization/_internal/commands/test_build.py:509:1: W191 indentation contains tabs
src/test/python/dlpx/virtualization/_internal/commands/test_codegen.py:374:89: E501 line too long (89 > 88 characters)
```

(see https://github.com/delphix/virtualization-sdk/pull/128/checks?check_run_id=668547116)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Ran formatting and linting tools locally to fix all the precommit errors.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
