### PR TITLE
Fixes #74 CI/CD: Write release GH Action: build and publish

### DIFF
--- a/.github/workflows/publish-python-packages.yml
+++ b/.github/workflows/publish-python-packages.yml
@@ -1,10 +1,8 @@
 name: Publish Python packages to Test PyPi
 
 on:
-  # Run on push when a tag is created or the version file has changed.
+  # Run on push when the version file has changed on selected branches.
   push:
-    tags:
-      - '*'
     branches:
       - master
       - develop

--- a/.github/workflows/publish-python-packages.yml
+++ b/.github/workflows/publish-python-packages.yml
@@ -1,0 +1,44 @@
+name: Publish Python packages to Test PyPi
+
+on:
+  # Run on push when a tag is created or the version file has changed.
+  push:
+    tags:
+      - '*'
+    branches:
+      - master
+      - develop
+      - 'release/**'
+    paths:
+      - 'dvp/src/main/python/dlpx/virtualization/VERSION'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version: [2.7]
+        package: [common, dvp, libs, platform, tools]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      # Install dependencies necessary for building and publishing the package.
+      - name: Install dependencies
+        run: |
+          pip install setuptools wheel twine
+      # Build each Python package and publish it to Test PyPi.
+      - name: Build and publish ${{ matrix.package }} package
+        working-directory: ${{ matrix.package }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.VSDK_PYPI_TOKEN }}
+          TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*
+


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Python packages are built and published to Test PyPi manually.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR adds a GitHub action with the following behavior: when the dvp VERSION file (`dvp/src/main/python/dlpx/virtualization/VERSION`) is changed on master, develop, or release branch, we will build all Python packages and publish them to Test PyPi.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I have tested this action on my fork. I have verified that the action connects and tries to upload to Test PyPi (see https://github.com/fdrozdowski/virtualization-sdk/runs/759631255?check_suite_focus=true):
```
Uploading distributions to https://test.pypi.org/legacy/
Uploading dvp_common-2.1.0.dev2-py2-none-any.whl

  0%|          | 0.00/14.1k [00:00<?, ?B/s]
HTTPError: 400 Client Error: File already exists. See https://test.pypi.org/help/#file-name-reuse for url: https://test.pypi.org/legacy/
100%|##########| 14.1k/14.1k [00:00<00:00, 54.5kB/s]
NOTE: Try --verbose to see response content.
##[error]Process completed with exit code 1.
```

It ultimately fails because this version of the package already exists on Test PyPi. Otherwise, the package would be uploaded.