### PR TITLE
Fixes #258 Add clearer doc for JSON schema's default keyword

### DIFF
--- a/docs/docs/References/Schemas.md
+++ b/docs/docs/References/Schemas.md
@@ -112,6 +112,9 @@ Here is a JSON object that conforms to the above schema:
 
 For much more detail on JSON schemas, including which keywords are available, what they mean, and where you can use them, see <https://json-schema.org/understanding-json-schema/>.
 
+!!! info
+    Be careful when using the JSON schema keyword `default`. This keyword is commonly misunderstood. Specifically, it does not mean "If the user does not provide a value, then this default value will be auto-substituted instead", as you might expect. In fact, in JSON schemas, `default` has no semantic meaning at all!
+
 
 ### Delphix-specific Extensions to JSON Schema
 
@@ -309,7 +312,7 @@ This will allow the plugin author to ask the user to select [environments](/Refe
     "type": "string",
     "format": "reference",
     "referenceType": "HOST_USER",
-    "matches”: "env"
+    "matches": "env"
   }
 }
 ```
@@ -337,7 +340,7 @@ The `referenceType` keyword is used to specify the [reference](#reference) type.
     "type": "string",
     "format": "reference",
     "referenceType": "HOST_USER",
-    "matches”: "env"
+    "matches": "env"
   }
 }
 ```
@@ -362,7 +365,7 @@ The `matches` keyword is used to map an [environment user](/References/Glossary.
     "type": "string",
     "format": "reference",
     "referenceType": "HOST_USER",
-    "matches”: "env"
+    "matches": "env"
   }
 }
 ```

--- a/docs/docs/References/Schemas.md
+++ b/docs/docs/References/Schemas.md
@@ -113,7 +113,7 @@ Here is a JSON object that conforms to the above schema:
 For much more detail on JSON schemas, including which keywords are available, what they mean, and where you can use them, see <https://json-schema.org/understanding-json-schema/>.
 
 !!! info
-    Be careful when using the JSON schema keyword `default`. This keyword is commonly misunderstood. Specifically, it does not mean "If the user does not provide a value, then this default value will be auto-substituted instead", as you might expect. In fact, in JSON schemas, `default` has no semantic meaning at all!
+    Be careful when using the JSON schema keyword `default`. This keyword is commonly misunderstood. Specifically, it does not mean "If the user does not provide a value, then this default value will be auto-substituted instead", as you might expect. In fact, in JSON schemas, `default` has no semantic meaning at all! Currently, the only thing the Delphix Engine will use this for is to pre-fill widgets on the UI.
 
 
 ### Delphix-specific Extensions to JSON Schema


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
No mention of `default`

## What is the new behavior?
Added a warning about misinterpreting JSON schema's `default` keyword.  (Also fixed a couple of incorrect quote characters)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Other information

