### PR TITLE
Document password vault support for VSDK plugins

### DIFF
--- a/docs/docs/References/Classes.md
+++ b/docs/docs/References/Classes.md
@@ -199,3 +199,93 @@ Field | Type | Description
 ----- | ---- | -----------
 name | String | User name.
 reference | String | Unique identifier for the user.
+
+
+## Credentials
+
+Abstract class representing credentials that include a user name. Instances of this class are returned by the [`retrieve_credentials`](Platform_Libraries.md#retrieve_credentials) library call.
+
+```python
+from dlpx.virtualization import libs
+from dlpx.virtualization.common import Credentials
+from dlpx.virtualization.platform import Plugin
+
+plugin = Plugin()
+
+@plugin.virtual.stop()
+def my_virtual_stop(virtual_source, repository, source_config):
+    credentials = libs.retrieve_credentials(virtual_source.parameters.credentials_supplier)
+    assert isinstance(credentials, Credentials)
+    environment_vars = {
+        "DATABASE_USERNAME" : credentials.username
+    }
+    ...
+```
+
+### Fields
+
+Field | Type | Description
+----- | ---- | -----------
+username | String | User name. Empty string if not present.
+
+
+## KeyPairCredentials
+
+Concrete subclass of [Credentials](#credentials) that represents key-pair credentials. Instances of this class may returned by the [`retrieve_credentials`](Platform_Libraries.md#retrieve_credentials) library call.
+
+```python
+from dlpx.virtualization import libs
+from dlpx.virtualization.common import KeyPairCredentials
+from dlpx.virtualization.platform import Plugin
+
+plugin = Plugin()
+
+@plugin.virtual.stop()
+def my_virtual_stop(virtual_source, repository, source_config):
+    credentials = libs.retrieve_credentials(virtual_source.parameters.key_pair_supplier)
+    assert isinstance(credentials, KeyPairCredentials)
+    environment_vars = {
+        "DATABASE_USERNAME" : credentials.username,
+        "DATABASE_PRIVATE_KEY" : credentials.private_key,
+        "DATABASE_PUBLIC_KEY" : credentials.public_key
+    }
+    ...
+```
+
+### Fields
+
+Field | Type | Description
+----- | ---- | -----------
+username | String | User name. Empty string if not present.
+private_key | String | Private key.
+public_key | String | Public key corresponding to private key. Empty string if not present.
+
+
+## PasswordCredentials
+
+Concrete subclass of [Credentials](#credentials) that represents password credentials. Instances of this class may returned by the [`retrieve_credentials`](Platform_Libraries.md#retrieve_credentials) library call.
+
+```python
+from dlpx.virtualization import libs
+from dlpx.virtualization.common import PasswordCredentials
+from dlpx.virtualization.platform import Plugin
+
+plugin = Plugin()
+
+@plugin.virtual.stop()
+def my_virtual_stop(virtual_source, repository, source_config):
+    credentials = libs.retrieve_credentials(virtual_source.parameters.password_supplier)
+    assert isinstance(credentials, PasswordCredentials)
+    environment_vars = {
+        "DATABASE_USERNAME" : credentials.username,
+        "DATABASE_PASSWORD" : credentials.password
+    }
+    ...
+```
+
+### Fields
+
+Field | Type | Description
+----- | ---- | -----------
+username | String | User name. Empty string if not present.
+password | String | Password.

--- a/docs/docs/References/Schemas.md
+++ b/docs/docs/References/Schemas.md
@@ -373,6 +373,213 @@ The `matches` keyword is used to map an [environment user](/References/Glossary.
 
 In the example above, environment user `envUser` maps to environment `env`.
 
+### Delphix-specific Pre-defined Types
+
+Plugins can also take advantage of pre-defined object types offered by Delphix. Currently, these object types let users supply credentials to plugins directly or via password vaults. Password vaults have [a number of benefits for securing and managing secrets](/Best_Practices/Sensitive_Data.md#protecting-sensitive-data-with-password-vaults).
+
+These pre-defined types can be referenced by JSON schemas via the external schema identifier `https://delphix.com/platform/api`. This is only an identifier, not a web address.
+
+The list below describes each of these definitions and shows how they can be referenced by plugins and users. (To understand how to use these objects at runtime, see [this section](/Best_Practices/Sensitive_Data.md#protecting-sensitive-data-with-password-vaults).)
+
+#### `credentialsSupplier`
+
+Defines an object type that lets users supply credentials consisting of a username (optional) and a secret. The secret can be a password or a private key. In case of a private key, a corresponding public key may also be included. This data can be entered directly by the user or supplied by a password vault. If as password or private key is entered directly, the UI will never show the value on screen, and the value will be encrypted before being stored as described [here](/Best_Practices/Sensitive_Data.md#marking-your-data-as-sensitive).
+
+An example of a JSON schema using this type is:
+
+```json
+"properties": {
+  "myCredentials": {
+    "$ref": "https://delphix.com/platform/api#/definitions/credentialsSupplier"
+  }
+}
+```
+where `credentialsSupplier` is a definition in the external schema `https://delphix.com/platform/api`.
+
+When providing data for a property of this type, the user has the following four options.
+
+##### Option 1: Username and password
+
+For this option, the user must provide data that satisfies this definition:
+```json
+{
+  "type": "object",
+  "required": ["type", "password"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "NamedPasswordCredential"
+    },
+    "username": {
+      "type": "string"
+    },
+    "password": {
+      "type": "string",
+      "format": "password"
+    }
+  }
+}
+```
+where `type` is a constant of value `NamedPasswordCredential`. This value is needed by the Delphix engine to determine the option being used. The graphical user interface will not show this element; it will send this constant value automatically to the Delphix engine.
+
+The `username` property is optional.
+
+For example, the user, or the user interface on behalf of the user, can provide:
+```json
+"properties": {
+  "myCredentials": {
+    "type": "NamedPasswordCredential",
+    "username": "my user name",
+    "password": "my password"
+  }
+}
+```
+
+##### Option 2: Username and key(s)
+
+For this option, the user must provide data that satisfies this definition:
+```json
+{
+  "type": "object",
+  "required": ["type", "privateKey"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "NamedKeyPairCredential"
+    },
+    "username": {
+      "type": "string"
+    },
+    "publicKey": {
+      "type": "string"
+    },
+    "privateKey": {
+      "type": "string",
+      "format": "password"
+    }
+  }
+}
+```
+where the `username` and `publicKey` properties are optional, and `type` is a constant that the
+user interface will submit automatically on behalf of the user.
+
+For example, the user, or the user interface on behalf of the user, can provide:
+```json
+"properties": {
+  "myCredentials": {
+    "type": "NamedKeyPairCredential",
+    "username": "my user name",
+    "publicKey": "AAA4QG...HBCDD3=",
+    "privateKey": "-----BEGIN RSA PRIVATE KEY-----...-----END RSA PRIVATE KEY-----"
+  }
+}
+```
+
+##### Option 3: CyberArk vault credentials
+
+For this option, the user must provide data that satisfies this definition:
+```json
+{
+  "type": "object",
+  "required": ["type", "vault", "queryString"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "CyberArkVaultCredential"
+    },
+    "vault": {
+      "type": "string",
+      "format": "reference",
+      "referenceType": "CyberArkPasswordVault"
+    },
+    "queryString": {
+      "type": "string"
+    },
+    "expectedSecretType": {
+      "type": "string",
+      "enum": ["any", "password", "keyPair"],
+      "default": "any"
+    }
+  }
+}
+```
+where `type` is a constant that the user interface will submit automatically on behalf of the user, `vault` is a reference to a CyberArk vault configured in the system, and `queryString` is a parameter for locating the credentials in the vault. For details on configuring and using CyberArk vaults, see the [password-vaults documentation for the Delphix engine](https://docs.delphix.com/docs/security/product-security/password-vault-support).
+
+Optionally, `expectedSecretType` lets the user constrain the secret returned by the vault to passwords or keys (the default is to allow `any` of those two types of secret). An unexpected type of secret returned by the vault will result in a runtime exception.
+
+For example, the user, or the user interface on behalf of the user, can provide:
+```json
+"properties": {
+  "myCredentials": {
+    "type": "CyberArkVaultCredential",
+    "vault": "CYBERARK_PASSWORD_VAULT-1",
+    "queryString": "Safe=test;Object=myObject"
+  }
+}
+```
+
+##### Option 4: HashiCorp vault credentials
+
+For this option, the user must provide data that satisfies this definition:
+```json
+{
+  "type": "object",
+  "required": ["type", "vault", "engine", "path", "usernameKey", "secretKey"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "HashiCorpVaultCredential"
+    },
+    "vault": {
+      "type": "string",
+      "format": "reference",
+      "referenceType": "HashiCorpVault"
+    },
+    "engine": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    },
+    "usernameKey": {
+      "type": "string"
+    },
+    "secretKey": {
+      "type": "string"
+    },
+    "expectedSecretType": {
+      "type": "string",
+      "enum": ["any", "password", "keyPair"],
+      "default": "any"
+    }
+  }
+}
+```
+where `type` is a constant that the user interface will submit automatically on behalf of the user, `vault` is a reference to a HashiCorp vault configured in the system, and `engine`, `path`, `usernameKey` and `secretKey` are parameters for locating the credentials in the vault. For details on configuring and using HashiCorp vaults, see the [password-vaults documentation for the Delphix engine](https://docs.delphix.com/docs/security/product-security/password-vault-support).
+
+Optionally, `expectedSecretType` lets the user constrain the secret returned by the vault to passwords or keys (the default is to allow `any` of those two types of secret). An unexpected type of secret returned by the vault will result in a runtime exception.
+
+The `type` property is a constant that the user interface will submit automatically on behalf of the user.
+
+For example, the user, or the user interface on behalf of the user, can provide:
+```json
+"properties": {
+  "myCredentials": {
+    "type": "HashiCorpVaultCredential",
+    "vault": "HASHICORP_VAULT-2",
+    "engine": "kv-v2",
+  }
+}
+```
+
+#### `keyCredentialsSupplier`
+
+This object type is identical to `credentialsSupplier` but requires the secrets to be keys. The available options are [keys](#option-2-username-and-keys), [CyberArk vaults](#option-3-cyberark-vault-credentials) and [HashiCorp vaults](#option-4-hashicorp-vault-credentials). The property `expectedSecretType` is required in all cases and must have the value `keyPair`.
+
+#### `passwordCredentialsSupplier`
+
+This object type is identical to `credentialsSupplier` but requires the secrets to be passwords. The available options are [passwords](#option-1-username-and-password), [CyberArk vaults](#option-3-cyberark-vault-credentials) and [HashiCorp vaults](#option-4-hashicorp-vault-credentials). The property `expectedSecretType` is required in all cases and must have the value `keyPair`.
+
 ## JSON Schema Limitations
 
 To be able to autogenerate Python classes there are some restrictions to the JSON Schemas that are supported.

--- a/docs/docs/Versioning_And_Upgrade/Upgrade.md
+++ b/docs/docs/Versioning_And_Upgrade/Upgrade.md
@@ -132,7 +132,9 @@ As shown above, the a data migration receives old-format input and produces new-
 
 * Data migrations are run in the order specified by their IDs. The ordering is numerical, not lexicographical. Thus `"1"` would run before `"2"`, which would run before `"10"`.
 
-* Data migrations have no access to [Platform Libraries](/References/Platform_Libraries.md) or remote hosts. For example: If a data migration attempts to use [run_bash](/References/Platform_Libraries.md#run_bash) the upgrade will fail.
+* With the exception of [`upgrade_password`](/References/Platform_Libraries.md#upgrade_password), data migrations have no access to most [Platform Libraries](/References/Platform_Libraries.md) or remote hosts. For example: If a data migration attempts to use [run_bash](/References/Platform_Libraries.md#run_bash) the upgrade will fail.
+
+* Password properties can be generalized to [credential-supplying objects](/References/Schemas.md#credentialssupplier) that offer alternative mechanisms for obtaining passwords and secrets, such as password vaults. To achieve that, a data migration must call [`upgrade_password`](/References/Platform_Libraries.md#upgrade_password).
 
 * Note that the above rules imply that at least one data migration is required any time a schema change is made that would invalidate any data produced using a previous version of the plugin. For example: adding a `"required"` property to the new schema.
 


### PR DESCRIPTION
Documents the new credentials-supplier feature that lets users choose between entering passwords/keys directly or linking to a password vault.

Preview: https://rasantel.github.io/virtualization-sdk/

Fixes #267 .