### PR TITLE
Update publish-docs to use a deploy_key

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ github.repository == matrix.repository }}
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.SDK_DEPLOY_KEY }}
           publish_dir: docs/site
           commit_message: Deploy to gh-pages 🚀
           user_name: "github-actions[bot]"


### PR DESCRIPTION
# Problem:
Docs deployment is currently broken as the permissions for the GITHUB_TOKEN seem to have changed. 
Our org seems to have the "restricted" default:
https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token

The publish-docs github action fails with:
>  /usr/bin/git push origin gh-pages
>  remote: Permission to delphix/virtualization-sdk.git denied to github-actions[bot].
>  fatal: unable to access 'https://github.com/delphix/virtualization-sdk.git/': The requested URL returned error: 403
>  Error: Action failed with "The process '/usr/bin/git' failed with exit code 128"

https://github.com/delphix/virtualization-sdk/runs/2878474054

# Solution:
Use a deploy_token instead.

# Testing
Created a deploy key in my personal fork and tested the docs deployment.

# Implementation:
Followed the instructions in:
https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-create-ssh-deploy-key
I've created a deploy key and secret called SDK_DEPLOY_KEY in our Delphix GitHub SDK repository.

I only updated the deployment to developer.delphix.com not the personal fork gh-pages since that seemed to work with the existing github token. If we update that as well, everyone would have to go and create a deploy key for their personal forks.

Merging to docs/3.1.0 first to get our public docs on developer.delphix.com up to date, will then merge this to develop.