### PR TITLE
Fix version number in doc header (#358)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Delphix Virtualization SDK 3.0.0
+site_name: Delphix Virtualization SDK 3.1.0
 theme:
   name: material
   custom_dir: 'material/'


### PR DESCRIPTION
Cherry-pick the following commit from `docs/3.1.0` to develop

```
commit 16b2559abc573de556cfa9520c9f6bb20f9d128f
Author: Tom Walsh <61519496+mothslaw@users.noreply.github.com>
Date:   Mon Mar 15 15:31:12 2021 -0400

    Fix version number in doc header (#358)
```