### PR TITLE
Update SDK Docs deployment to use a deploy_key (#392)

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ github.repository == matrix.repository }}
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.SDK_DEPLOY_KEY }}
           publish_dir: docs/site
           commit_message: Deploy to gh-pages 🚀
           user_name: "github-actions[bot]"


### PR DESCRIPTION
Clean cherry-pick of the following commit from `docs/3.1.0` to `develop`

```
commit c1ee1b4214cb5c09dc15b1abd815e9d44909a5b3 (upstream/docs/3.1.0)
Author: ankursarin <ankursarin@gmail.com>
Date:   Fri Sep 10 09:28:07 2021 -0700

    Update SDK Docs deployment to use a deploy_key (#392)
```