### PR TITLE
CP-6006 Futurize vSDK - Stage 1

### DIFF
--- a/common/src/main/python/dlpx/virtualization/common/_common_classes.py
+++ b/common/src/main/python/dlpx/virtualization/common/_common_classes.py
@@ -3,6 +3,7 @@
 #
 
 from abc import ABCMeta
+import six
 from dlpx.virtualization.api import common_pb2, libs_pb2
 from dlpx.virtualization.common.exceptions import IncorrectTypeError
 from enum import IntEnum
@@ -101,19 +102,19 @@ class RemoteEnvironment(object):
 
     """
     def __init__(self, name, reference, host):
-        if not isinstance(name, basestring):
+        if not isinstance(name, six.string_types):
             raise IncorrectTypeError(
                 RemoteEnvironment,
                 'name',
                 type(name),
-                basestring)
+                six.string_types[0])
         self.__name = name
-        if not isinstance(reference, basestring):
+        if not isinstance(reference, six.string_types):
             raise IncorrectTypeError(
                 RemoteEnvironment,
                 'reference',
                 type(reference),
-                basestring)
+                six.string_types[0])
         self.__reference = reference
 
         if isinstance(host, RemoteHost):
@@ -172,33 +173,33 @@ class RemoteHost(object):
 
     """
     def __init__(self, name, reference, binary_path, scratch_path):
-        if not isinstance(name, basestring):
+        if not isinstance(name, six.string_types):
             raise IncorrectTypeError(
                 RemoteHost,
                 'name',
                 type(name),
-                basestring)
+                six.string_types[0])
         self.__name = name
-        if not isinstance(reference, basestring):
+        if not isinstance(reference, six.string_types):
             raise IncorrectTypeError(
                 RemoteHost,
                 'reference',
                 type(reference),
-                basestring)
+                six.string_types[0])
         self.__reference = reference
-        if not isinstance(binary_path, basestring):
+        if not isinstance(binary_path, six.string_types):
             raise IncorrectTypeError(
                 RemoteHost,
                 'binary_path',
                 type(binary_path),
-                basestring)
+                six.string_types[0])
         self.__binary_path = binary_path
-        if not isinstance(scratch_path, basestring):
+        if not isinstance(scratch_path, six.string_types):
             raise IncorrectTypeError(
                 RemoteHost,
                 'scratch_path',
                 type(scratch_path),
-                basestring)
+                six.string_types[0])
         self.__scratch_path = scratch_path
 
     @property
@@ -255,19 +256,19 @@ class RemoteUser(object):
         reference: Reference of the RemoteUser.
     """
     def __init__(self, name, reference):
-        if not isinstance(name, basestring):
+        if not isinstance(name, six.string_types):
             raise IncorrectTypeError(
                 RemoteUser,
                 'name',
                 type(name),
-                basestring)
+                six.string_types[0])
         self.__name = name
-        if not isinstance(reference, basestring):
+        if not isinstance(reference, six.string_types):
             raise IncorrectTypeError(
                 RemoteUser,
                 'reference',
                 type(reference),
-                basestring)
+                six.string_types[0])
         self.__reference = reference
 
     @property
@@ -311,12 +312,12 @@ class Credentials(object):
         username: User name.
     """
     def __init__(self, username):
-        if not isinstance(username, basestring):
+        if not isinstance(username, six.string_types):
             raise IncorrectTypeError(
                 Credentials,
                 'username',
                 type(username),
-                basestring)
+                six.string_types[0])
         self.__username = username
 
     __metaclass__ = ABCMeta
@@ -339,12 +340,12 @@ class PasswordCredentials(Credentials):
     """
     def __init__(self, username, password):
         super(PasswordCredentials, self).__init__(username)
-        if not isinstance(password, basestring):
+        if not isinstance(password, six.string_types):
             raise IncorrectTypeError(
                 PasswordCredentials,
                 'password',
                 type(password),
-                basestring)
+                six.string_types[0])
         self.__password = password
 
     @property
@@ -379,19 +380,19 @@ class KeyPairCredentials(Credentials):
     """
     def __init__(self, username, private_key, public_key):
         super(KeyPairCredentials, self).__init__(username)
-        if not isinstance(private_key, basestring):
+        if not isinstance(private_key, six.string_types):
             raise IncorrectTypeError(
                 KeyPairCredentials,
                 'private_key',
                 type(private_key),
-                basestring)
+                six.string_types[0])
         self.__private_key = private_key
-        if not isinstance(public_key, basestring):
+        if not isinstance(public_key, six.string_types):
             raise IncorrectTypeError(
                 KeyPairCredentials,
                 'public_key',
                 type(public_key),
-                basestring)
+                six.string_types[0])
         self.__public_key = public_key
 
     @property

--- a/libs/src/main/python/dlpx/virtualization/libs/libs.py
+++ b/libs/src/main/python/dlpx/virtualization/libs/libs.py
@@ -37,6 +37,7 @@ from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Struct
 
 import logging
+import six
 
 
 __all__ = [
@@ -135,23 +136,23 @@ def run_bash(remote_connection, command, variables=None, use_login_shell=False,
             'remote_connection',
             type(remote_connection),
             RemoteConnection)
-    if not isinstance(command, basestring):
-        raise IncorrectArgumentTypeError('command', type(command), basestring)
+    if not isinstance(command, six.string_types):
+        raise IncorrectArgumentTypeError('command', type(command), six.string_types[0])
     if variables and not isinstance(variables, dict):
         raise IncorrectArgumentTypeError(
             'variables',
             type(variables),
-            {basestring: basestring},
+            {six.string_types[0]: six.string_types[0]},
             False)
-    if (variables and (not all(isinstance(variable, basestring)
+    if (variables and (not all(isinstance(variable, six.string_types)
                                for variable in variables.keys()) or
-                       not all(isinstance(value, basestring)
+                       not all(isinstance(value, six.string_types)
                                for value in variables.values()))):
         raise IncorrectArgumentTypeError(
             'variables',
             {(type(variable), type(value))
              for variable, value in variables.items()},
-            {basestring: basestring},
+            {six.string_types[0]: six.string_types[0]},
             False)
     if use_login_shell and not isinstance(use_login_shell, bool):
         raise IncorrectArgumentTypeError(
@@ -198,40 +199,40 @@ def run_sync(remote_connection, source_directory, rsync_user=None,
             'remote_connection',
             type(remote_connection),
             RemoteConnection)
-    if not isinstance(source_directory, basestring):
+    if not isinstance(source_directory, six.string_types):
         raise IncorrectArgumentTypeError(
-            'source_directory', type(source_directory), basestring)
-    if rsync_user and not isinstance(rsync_user, basestring):
+            'source_directory', type(source_directory), six.string_types[0])
+    if rsync_user and not isinstance(rsync_user, six.string_types):
         raise IncorrectArgumentTypeError(
             'rsync_user',
             type(rsync_user),
-            basestring,
+            six.string_types[0],
             False)
     if exclude_paths and not isinstance(exclude_paths, list):
         raise IncorrectArgumentTypeError(
             'exclude_paths',
             type(exclude_paths),
-            [basestring],
+            [six.string_types[0]],
             False)
     if (exclude_paths and not all(isinstance(
-            path, basestring) for path in exclude_paths)):
+            path, six.string_types) for path in exclude_paths)):
         raise IncorrectArgumentTypeError(
             'exclude_paths',
             [type(path) for path in exclude_paths],
-            [basestring],
+            [six.string_types[0]],
             False)
     if sym_links_to_follow and not isinstance(sym_links_to_follow, list):
         raise IncorrectArgumentTypeError(
             'sym_links_to_follow',
             type(sym_links_to_follow),
-            [basestring],
+            [six.string_types[0]],
             False)
-    if (sym_links_to_follow and not all(isinstance(link, basestring)
+    if (sym_links_to_follow and not all(isinstance(link, six.string_types)
                                         for link in sym_links_to_follow)):
         raise IncorrectArgumentTypeError(
             'sym_links_to_follow',
             [type(link) for link in sym_links_to_follow],
-            [basestring],
+            [six.string_types[0]],
             False)
 
     run_sync_request = libs_pb2.RunSyncRequest()
@@ -288,23 +289,23 @@ def run_powershell(remote_connection, command, variables=None, check=False):
             'remote_connection',
             type(remote_connection),
             RemoteConnection)
-    if not isinstance(command, basestring):
-        raise IncorrectArgumentTypeError('command', type(command), basestring)
+    if not isinstance(command, six.string_types[0]):
+        raise IncorrectArgumentTypeError('command', type(command), six.string_types[0])
     if variables and not isinstance(variables, dict):
         raise IncorrectArgumentTypeError(
             'variables',
             type(variables),
-            {basestring: basestring},
+            {six.string_types[0]: six.string_types[0]},
             False)
-    if (variables and (not all(isinstance(variable, basestring)
+    if (variables and (not all(isinstance(variable, six.string_types)
                                for variable in variables.keys()) or
-                       not all(isinstance(value, basestring)
+                       not all(isinstance(value, six.string_types)
                                for value in variables.values()))):
         raise IncorrectArgumentTypeError(
             'variables',
             {(type(variable), type(value))
              for variable, value in variables.items()},
-            {basestring: basestring},
+            {six.string_types[0]: six.string_types[0]},
             False)
 
     run_powershell_request = libs_pb2.RunPowerShellRequest()
@@ -353,23 +354,23 @@ def run_expect(remote_connection, command, variables=None, check=False):
             'remote_connection',
             type(remote_connection),
             RemoteConnection)
-    if not isinstance(command, basestring):
-        raise IncorrectArgumentTypeError('command', type(command), basestring)
+    if not isinstance(command, six.string_types):
+        raise IncorrectArgumentTypeError('command', type(command), six.string_types[0])
     if variables and not isinstance(variables, dict):
         raise IncorrectArgumentTypeError(
             'variables',
             type(variables),
-            {basestring: basestring},
+            {six.string_types[0]: six.string_types[0]},
             False)
-    if (variables and (not all(isinstance(variable, basestring)
+    if (variables and (not all(isinstance(variable, six.string_types)
                                for variable in variables.keys()) or
-                       not all(isinstance(value, basestring)
+                       not all(isinstance(value, six.string_types)
                                for value in variables.values()))):
         raise IncorrectArgumentTypeError(
             'variables',
             {(type(variable), type(value))
              for variable, value in variables.items()},
-            {basestring: basestring},
+            {six.string_types[0]: six.string_types[0]},
             False)
 
     run_expect_request = libs_pb2.RunExpectRequest()
@@ -455,17 +456,17 @@ def upgrade_password(password, username=None):
     value into a more generic credentials supplier object.
 
     Args:
-        password (basestring): Plain password string.
-        username (basestring, defaults to None): User name contained in the password credential supplier to return.
+        password (str): Plain password string.
+        username (str, defaults to None): User name contained in the password credential supplier to return.
     Return:
         Credentials supplier (dict) that supplies the given password and username.
     """
     from dlpx.virtualization._engine import libs as internal_libs
 
-    if not isinstance(password, basestring):
-        raise IncorrectArgumentTypeError('password', type(password), basestring)
-    if username and not isinstance(username, basestring):
-        raise IncorrectArgumentTypeError('username', type(username), basestring, required=False)
+    if not isinstance(password, six.string_types):
+        raise IncorrectArgumentTypeError('password', type(password), six.string_types[0])
+    if username and not isinstance(username, six.string_types):
+        raise IncorrectArgumentTypeError('username', type(username), six.string_types[0], required=False)
 
     upgrade_password_request = libs_pb2.UpgradePasswordRequest()
     upgrade_password_request.password = password

--- a/platform/src/main/python/dlpx/virtualization/platform/migration_helper.py
+++ b/platform/src/main/python/dlpx/virtualization/platform/migration_helper.py
@@ -3,6 +3,7 @@
 #
 
 import re
+import six
 
 from dlpx.virtualization.platform import validation_util as v
 from dlpx.virtualization.platform.exceptions import (
@@ -142,7 +143,7 @@ class PlatformUpgradeMigrations(UpgradeMigrations):
     @staticmethod
     def __validate_migration_id(migration_id, impl_name):
         # First validate that the id is a string
-        if not isinstance(migration_id, basestring):
+        if not isinstance(migration_id, six.string_types):
             raise MigrationIdIncorrectTypeError(migration_id, impl_name)
 
         # Next check if the id is the right format
@@ -260,7 +261,7 @@ class LuaUpgradeMigrations(UpgradeMigrations):
     def __validate_lua_major_minor_version(migration_id, impl_name,
                                            decorator_name, impl_getter):
         # First validate that the major minor version is a string
-        if not isinstance(migration_id, basestring):
+        if not isinstance(migration_id, six.string_types):
             raise MigrationIdIncorrectTypeError(migration_id, impl_name)
 
         # Next check if the id already exists in this particular dictionary

--- a/platform/src/test/python/dlpx/virtualization/test_migration_helper.py
+++ b/platform/src/test/python/dlpx/virtualization/test_migration_helper.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 #
 # Copyright (c) 2019 by Delphix. All rights reserved.
 #
 
 import pytest
-import conftest
+from . import conftest
 from dlpx.virtualization.platform import migration_helper as m
 from dlpx.virtualization.platform.exceptions import (
     MigrationIdAlreadyUsedError, MigrationIdIncorrectFormatError,

--- a/platform/src/test/python/dlpx/virtualization/test_plugin.py
+++ b/platform/src/test/python/dlpx/virtualization/test_plugin.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 #
 # Copyright (c) 2019 by Delphix. All rights reserved.
 #
@@ -13,8 +14,8 @@ from dlpx.virtualization.platform.exceptions import (
     OperationAlreadyDefinedError, PluginRuntimeError)
 from mock import MagicMock, patch
 
-import fake_generated_definitions
-from fake_generated_definitions import (RepositoryDefinition,
+from . import fake_generated_definitions
+from .fake_generated_definitions import (RepositoryDefinition,
                                         SnapshotDefinition,
                                         SourceConfigDefinition)
 

--- a/tools/src/main/python/dlpx/virtualization/_internal/codegen.py
+++ b/tools/src/main/python/dlpx/virtualization/_internal/codegen.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import shutil
+import six
 import subprocess
 
 from dlpx.virtualization._internal import const, exceptions, file_util
@@ -97,7 +98,7 @@ def generate_python(name, source_dir, plugin_config_dir, schema_content):
 def _make_url_refs_opaque(json):
     if isinstance(json, dict):
         for key in json:
-            if key == '$ref' and isinstance(json[key], basestring)\
+            if key == '$ref' and isinstance(json[key], six.string_types)\
               and json[key].startswith('https://delphix.com/platform/api#'):
                 json.pop(key)
                 json['type'] = 'object'

--- a/tools/src/main/python/dlpx/virtualization/_internal/codegen/templates/base_model_.mustache
+++ b/tools/src/main/python/dlpx/virtualization/_internal/codegen/templates/base_model_.mustache
@@ -170,7 +170,7 @@ class GeneratedClassesTypeError(GeneratedClassesError):
             container then we assume there is one element in it and that type
             is the expected type of the container. (For dicts this is the key)
             ie: if expected_type = {str} then the returned expected string with
-            be something like "type 'dict with key basestring'"
+            be something like "type 'dict with key str'"
 
         Returns:
             tuple (str, str): the actual and expected strings used for the
@@ -284,11 +284,11 @@ class GeneratedClassesTypeError(GeneratedClassesError):
                                                  float,
                                                  required)
         elif expected_type == str:
-            if not isinstance(parameter, basestring):
+            if not isinstance(parameter, six.string_types):
                 return GeneratedClassesTypeError(object_type,
                                                  parameter_name,
                                                  type(parameter),
-                                                 basestring,
+                                                 six.string_types[0],
                                                  required)
         elif expected_type == list:
             if element_type:
@@ -324,7 +324,7 @@ class GeneratedClassesTypeError(GeneratedClassesError):
                 return GeneratedClassesTypeError(object_type,
                                                  parameter_name,
                                                  type(parameter),
-                                                 {basestring},
+                                                 {six.string_types[0]},
                                                  required)
 
             #
@@ -341,21 +341,21 @@ class GeneratedClassesTypeError(GeneratedClassesError):
                 else:
                     value_check = all(isinstance(v, element_type)
                                       for v in parameter.values())
-                if (not all(isinstance(k, basestring)
+                if (not all(isinstance(k, six.string_types)
                             for k in parameter.keys()) or not value_check):
                     return GeneratedClassesTypeError(
                         object_type,
                         parameter_name,
                         {(type(k), type(v)) for k, v in parameter.items()},
-                        {basestring: element_type},
+                        {six.string_types[0]: element_type},
                         required)
             else:
-                if not all(isinstance(k, basestring) for k in parameter.keys()):
+                if not all(isinstance(k, six.string_types[0]) for k in parameter.keys()):
                     return GeneratedClassesTypeError(
                         object_type,
                         parameter_name,
                         {type(k) for k in parameter.keys()},
-                        {basestring},
+                        {six.string_types[0]},
                         required)
 
         else:

--- a/tools/src/main/python/dlpx/virtualization/_internal/codegen/templates/util.mustache
+++ b/tools/src/main/python/dlpx/virtualization/_internal/codegen/templates/util.mustache
@@ -33,9 +33,9 @@ def get_contained_type(type_string):
     for pattern in patterns:
         match = re.search(pattern, type_string)
         if match and match.group(1) != 'ERRORUNKNOWN':
-            # Convert the type to basestring here.
+            # Convert the type to str here.
             if match.group(1) == 'str':
-                return basestring
+                return six.string_types[0]
             return pydoc.locate(match.group(1))
     return None
 
@@ -73,7 +73,7 @@ def _deserialize(data, klass):
     if data is None:
         return None
 
-    if issubclass(klass, (int, float, long, complex, basestring, bool)):
+    if issubclass(klass, (int, float, long, complex, six.string_types[0], bool)):
         return _deserialize_primitive(data, klass)
     elif klass == datetime.date:
         return deserialize_date(data)
@@ -93,8 +93,8 @@ def _deserialize_primitive(data, klass):
     :param data: data to deserialize.
     :param klass: class literal.
 
-    :return: int, float, long, complex, basestring, bool.
-    :rtype: int | float | long | complex | basestring | bool
+    :return: int, float, long, complex, str, bool.
+    :rtype: int | float | long | complex | str | bool
     """
     try:
         value = klass(data)


### PR DESCRIPTION
# Context:
This change begins preparing for the move to Python3.8 by running `futurize --stage1 ...` against all 5 packages (very few changes), and by using `six` to remove all direct references to `basestring` in the source code. CP-6009 will handle all other vSDK changes for this project. In Py2, `six.string_types = [basestring]` and in Py3, `six.string_types = [str]`. This will also take a little bit of weight off of the upcoming CP-6009 review, which can then focus mainly on introducing `to_str` and `to_bytes` helpers across the repo as necessary.


# Testing
Blackbox:
[virtualization_sdk](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-self-service/113073/consoleFull)
[appdata_basic](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-self-service/113076/consoleFull)
and unit tests passed