### PR TITLE
CP-6694 Update docs for SDK 4.0.0

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [2.7]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-10.15, windows-latest]
         package: [common, libs, platform]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ The latest user documentation can be found [here](https://developer.delphix.com)
 ### Prerequisites
 
 - macOS 10.14+, Ubuntu 16.04+, or Windows 10
-- Python 2.7 (Python 3 is not supported)
+- Python 2.7 (vSDK 3.1.0 and earlier)
+- Python 3.8 (vSDK 4.0.0 and later)
 - Java 7+
-- Delphix Engine 5.3.5.0 or above
+- A Delphix Engine of an [appropriate version](/References/Version_Compatibility.md)
 
 ### Installing
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -70,7 +70,7 @@ We have two goals: Provide the best documentation we can for our customers, and 
 
 1. Learn Markdown or use a really good IDE. It's easy to use, but there are complex topics like tables, admonishments, links, and images that you may need some practice with. Look at the other docs in the repo for inspiration and tutelage.
 2. Test everything in mkdocs locally. Best practice is to always have mkdocs running in one terminal tab. It auto-refreshes when you make changes, so you can make sure that nothing breaks, and that your content looks good.
-3. Do not create new directories (nav categories) in /docs without working with Jaspal Sumal (jaspal.sumal@delphix.com)
+3. Do not create new directories (nav categories) in /docs without working with Ryan Fowler (ryan.fowler@delphix.com)
 4. Place all screenshots in the local media/ directory of the category you're editing in. For example, if you're editing a page in docs/Getting_Started, put any screenshots you're going to use in docs/Getting_Started/media
 5. Use relative links to reference screenshots (./media/image.png) and other pages (../Getting_Started/pagename/)
 6. Beware the .pages file. .pages is a hidden file in every folder that provides page order. Any pages not listed in .pages will be alphabetically ordered _after_ the pages that have been listed. If you have a typo in this file or specify a renamed/deleted page, it will break mkdocs.
@@ -84,16 +84,16 @@ We have two goals: Provide the best documentation we can for our customers, and 
 
 1. The diff can usually provide what you need for reviewing changes. However, use mkdocs to review locally whenever possible to ensure good formatting and no breaks to mkdocs.
 2. For minor corrections, leave a general comment on the review and vote to ship it so the author can fix it and push.
-3. For major docs projects (e.g. whole new sections of docs or large batches of changes), coordinate with Jas. It is possible we'd be better off using another approach to review (e.g. track notes via Google Sheets)
-4. If you're a reviewer that is not hooked into reviewboard, and unable to get set up to use it, work with Jas on an alternative approach (e.g. track notes via Google Sheets)
+3. For major docs projects (e.g. whole new sections of docs or large batches of changes), coordinate with Ryan. It is possible we'd be better off using another approach to review (e.g. track notes via Google Sheets)
+4. If you're a reviewer that is not hooked into reviewboard, and unable to get set up to use it, work with Ryan on an alternative approach (e.g. track notes via Google Sheets)
 5. If there are issues in production docs, the current procedure is to post the issue in the #docs channel.
 
 ## Publishing
 
 Publishing is currently a manual process that will be automated into the release process at a future point in time. The publishing workflow follows these steps:
 
-1. After the git repo is frozen, Jas begins review and adjustments.
-2. If there are technical questions or issues, Jas will take back to engineering for review.
+1. After the git repo is frozen, Ryan begins review and adjustments.
+2. If there are technical questions or issues, Ryan will take back to engineering for review.
 3. The publish process will run. This process will:
   * Pull the appropriate branch to a build machine
   * Run "mkdocs build clean" to compile documentation to HTML

--- a/docs/docs/Best_Practices/Managing_Scripts_For_Remote_Execution.md
+++ b/docs/docs/Best_Practices/Managing_Scripts_For_Remote_Execution.md
@@ -1,8 +1,10 @@
 # Managing Scripts for Remote Execution
 
-To execute a PowerShell or Bash script or Expect script on a remote host, you must provide the script as a string to `run_powershell` or `run_bash` or `run_expect`. While you can keep these strings as literals in your Python code, best practice is to keep them as resource files in your source directory and access them with `pkgutil`.
+To execute a PowerShell or Bash script or Expect script on a remote host, you must provide the script as a string to `run_powershell` or `run_bash` or `run_expect`. While you can keep these strings as literals in your Python code, best practice is to keep them as resource files in your source directory and access them with `pkgutil` or `importlib`, depending on your plugin language.
 
 [pkgutil](https://docs.python.org/2/library/pkgutil.html) is part of the standard Python library. The method that is applicable to resources is [pkgutil.get_data](https://docs.python.org/2/library/pkgutil.html#pkgutil.get_data).
+
+When developing a plugin in Python3, it is instead suggested to use the newer `importlib.resources`. This package is part of the standard Python 3 library. The method that is applicable to resources is [resources.read_text](https://docs.python.org/3.8/library/importlib.html#importlib.resources.read_text), which accepts the same arguments as `pkgutil.get_data`.
 
 ### Basic Usage
 
@@ -66,7 +68,7 @@ def post_snapshot(direct_source, repository, source_config):
 		raise UserError(
 		'Failed to get date',
 		'Make sure the user has the required permissions',
-		'{}\n{}'.format(response.stdout, rsponse.stderr))
+		'{}\n{}'.format(response.stdout, response.stderr))
 
 	return SnapshotDefinition(name='Snapshot', date=response.stdout)
 ```
@@ -75,7 +77,9 @@ def post_snapshot(direct_source, repository, source_config):
 	This assumes that `src/` is Python's current working directory. This is the behavior of the Virtualization Platform.
 
 !!! warning "Resources need to be in a Python module"
-	`pkgutil.get_data` cannot retrieve the contents of a resource that is not in a Python package. This means that a resource that is in the first level of your source directory will not be retrievable with `pkgutil`. Resources must be in a subdirectory of your source directory, and that subdirectory must contain an `__init__.py` file.
+	`pkgutil.get_data` cannot retrieve the contents of a resource that is not in a Python package. When developing with Python 2.7, this means that a resource that is in the first level of your source directory will not be retrievable with `pkgutil`. Resources must be in a subdirectory of your source directory, and that subdirectory must contain an `__init__.py` file.
+
+	Python 3 does not have this requirement.
 
 ### Multi-level Packages
 
@@ -100,4 +104,10 @@ The contents of `src/resources/platform/get_date.sh` can be retrieved with:
 
 ```python
 script_content = pkgutil.get_data('resources.platform', 'get_date.sh')
+```
+
+In a Python 3.8 plugin, the suggested approach is:
+
+```python
+script_content = resources.read_text('resources.platform', 'get_date.sh')
 ```

--- a/docs/docs/Best_Practices/User_Visible_Errors.md
+++ b/docs/docs/Best_Practices/User_Visible_Errors.md
@@ -16,7 +16,7 @@ output | String | **Optional**. Output or stack trace from the failure to give t
 ## Example
 
 ```python
-import pkgutil
+from importlib import resources
 from dlpx.virtualization.platform import Plugin
 from generated.definitions import SourceConfigDefinition
 from dlpx.virtualization.platform.exceptions import UserError
@@ -25,7 +25,7 @@ plugin = Plugin()
 
 @plugin.virtual.start()
 def start(virtual_source, repository, source_config):
-  script_content = pkgutil.get_data('resources', 'start_database.sh')
+  script_content = resources.read_text('resources', 'start_database.sh')
 
   response = libs.run_bash(virtual_source.connection, script_content)
 
@@ -36,6 +36,11 @@ def start(virtual_source, repository, source_config):
     'Make sure the user has appropriate permissions',
     '{}\n{}'.format(response.stdout, response.stderr))
 ```
+
+!!! warning
+    If developing a plugin in Python 2.7, you will need to use `pkgutil.get_data` rather than `importlib.resources.read_text`.
+
+    See [Managing Scripts For Remote Execution](/Best_Practices/Managing_Scripts_For_Remote_Execution.md) for more info.
 
 The UI would show the end user if the plugin operation above fails:
 

--- a/docs/docs/Getting_Started.md
+++ b/docs/docs/Getting_Started.md
@@ -12,9 +12,10 @@ The platform and libs modules expose objects and methods needed to develop a plu
 ## Requirements
 
 - macOS 10.14+, Ubuntu 16.04+, or Windows 10
-- Python 2.7 (Python 3 is not supported)
+- Python 2.7 (vSDK 3.1.0 and earlier)
+- Python 3.8 (vSDK 4.0.0 and later)
 - Java 7+
-- Delphix Engine 6.0.7.0 or above
+- A Delphix Engine of an [appropriate version](/References/Version_Compatibility.md)
 
 ## Installation
 To install the latest version of the SDK run:
@@ -26,9 +27,13 @@ $ pip install dvp
 !!! tip "Use a Virtual Environment"
 	 We highly recommended that you develop plugins inside of a virtual environment. To learn more about virtual environments, refer to [Virtualenv's documentation](https://virtualenv.pypa.io/en/latest/).
 
-	 The virtual environment needs to use Python 2.7. This is configured when creating the virtualenv:
+     If using vSDK 3.1.0 or earlier, the virtual environment needs to use Python 2.7.
 
-	 ```$ virtualenv -p /path/to/python2.7/binary ENV```
+     If using vSDK 4.0.0 or earlier, the virtual environment needs to use Python 3.8.
+
+	 This is configured when creating the virtualenv:
+
+	 ```$ virtualenv -p /path/to/python2.7/binary ENV``` or ```$ virtualenv -p /path/to/python3.8/binary ENV```
 
 To install a specific version of the SDK run:
 

--- a/docs/docs/References/Decorators.md
+++ b/docs/docs/References/Decorators.md
@@ -13,7 +13,7 @@ plugin = Plugin()
 # Use the decorator to annotate the function that corresponds to the "Virtual Source Start" Plugin Operation
 @plugin.virtual_source.start()
 def my_start(virtual_source, repository, source_config):
-  print "running start"
+  print("running start")
 ```
 
 !!! info

--- a/docs/docs/References/Logging.md
+++ b/docs/docs/References/Logging.md
@@ -6,10 +6,10 @@ The Virtualization Platform keeps plugin-specific log files. A plugin can, at an
 
 ## Overview
 
-The Virtualization Platform integrates with Python's built-in [logging framework](https://docs.python.org/2/library/logging.html). A special [Handler](https://docs.python.org/2/library/logging.html#handler-objects) is exposed by the platform at `dlpx.virtualization.libs.PlatformHandler`. This handler needs to be added to the Python logger your plugin creates. Logging statements made through Python's logging framework will then be routed to the platform.
+The Virtualization Platform integrates with Python's built-in [logging framework](https://docs.python.org/3.8/library/logging.html). A special [Handler](https://docs.python.org/3.8/library/logging.html#handler-objects) is exposed by the platform at `dlpx.virtualization.libs.PlatformHandler`. This handler needs to be added to the Python logger your plugin creates. Logging statements made through Python's logging framework will then be routed to the platform.
 
 ## Basic Setup
- Below is the absolute minimum needed to setup logging for the platform. Please refer to Python's [logging documentation](https://docs.python.org/2/library/logging.html) and the [example below](#customized-example) to better understand how it can be customized.
+ Below is the absolute minimum needed to setup logging for the platform. Please refer to Python's [logging documentation](https://docs.python.org/3.8/library/logging.html) and the [example below](#customized-example) to better understand how it can be customized.
 
 ```python
 import logging
@@ -40,7 +40,7 @@ logger.setLevel(logging.DEBUG)
     There is a limit to how much data can be stored within a log message. See [Message Limits](/Best_Practices/Message_Limits.md) for details.
 	
 ## Usage
-Once the `PlatformHandler` has been added to the logger, logging is done with Python's [Logger](https://docs.python.org/2/library/logging.html#logger-objects) object. Below is a simple example including the basic setup code used above:
+Once the `PlatformHandler` has been added to the logger, logging is done with Python's [Logger](https://docs.python.org/3.8/library/logging.html#logger-objects) object. Below is a simple example including the basic setup code used above:
 
 ```python
 import logging
@@ -68,7 +68,7 @@ Imagine you notice that your plugin is taking a very long time to do discovery. 
 
 Suppose your plugin has a source config discovery operation that looks like this (code is abbreviated to be easier to follow):
 ```python
-import pkgutil
+from importlib import resources
 
 from dlpx.virtualization import libs
 from dlpx.virtualization.platform import Plugin
@@ -83,10 +83,10 @@ def repository_discovery(source_connection):
 
 @plugin.discovery.source_config()
 def source_config_discovery(source_connection, repository):
-  version_result = libs.run_bash(source_connection, pkgutil.get_data('resources', 'get_db_version.sh'))
-  users_result = libs.run_bash(source_connection, pkgutil.get_data('resources', 'get_db_users.sh'))
-  db_results = libs.run_bash(source_connection, pkgutil.get_data('resources', 'get_databases.sh'))
-  status_result = libs.run_bash(source_connection, pkgutil.get_data('resources', 'get_database_statuses.sh'))
+  version_result = libs.run_bash(source_connection, resources.read_text('resources', 'get_db_version.sh'))
+  users_result = libs.run_bash(source_connection, resources.read_text('resources', 'get_db_users.sh'))
+  db_results = libs.run_bash(source_connection, resources.read_text('resources', 'get_databases.sh'))
+  status_result = libs.run_bash(source_connection, resources.read_text('resources', 'get_database_statuses.sh'))
 
   # Return an empty list for simplicity. In reality
   # something would be done with the results above.
@@ -94,10 +94,15 @@ def source_config_discovery(source_connection, repository):
  
 ```
 
+!!! warning
+    If developing a plugin in Python 2.7, you will need to use `pkgutil.get_data` rather than `importlib.resources.read_text`.
+
+    See [Managing Scripts For Remote Execution](/Best_Practices/Managing_Scripts_For_Remote_Execution.md) for more info.
+
 Now, imagine that you notice that it's taking a long time to do discovery, and you'd like to try to figure out why. One thing that might help is to add logging, like this:
 ```python
 import logging
-import pkgutil
+from importlib import resources
 
 from dlpx.virtualization import libs
 from dlpx.virtualization.platform import Plugin
@@ -143,13 +148,13 @@ def repository_discovery(source_connection):
 @plugin.discovery.source_config()
 def source_config_discovery(source_connection, repository):
   logger.debug('About to get DB version')
-  version_result = libs.run_bash(source_connection, pkgutil.get_data('resources', 'get_db_version.sh'))
+  version_result = libs.run_bash(source_connection, resources.read_text('resources', 'get_db_version.sh'))
   logger.debug('About to get DB users')
-  users_result = libs.run_bash(source_connection, pkgutil.get_data('resources', 'get_db_users.sh'))
+  users_result = libs.run_bash(source_connection, resources.read_text('resources', 'get_db_users.sh'))
   logger.debug('About to get databases')
-  db_results = libs.run_bash(source_connection, pkgutil.get_data('resources', 'get_databases.sh'))
+  db_results = libs.run_bash(source_connection, resources.read_text('resources', 'get_databases.sh'))
   logger.debug('About to get DB statuses')
-  status_result = libs.run_bash(source_connection, pkgutil.get_data('resources', 'get_database_statuses.sh'))
+  status_result = libs.run_bash(source_connection, resources.read_text('resources', 'get_database_statuses.sh'))
   logger.debug('Done collecting data')
   
   # Return an empty list for simplicity. In reality
@@ -176,7 +181,7 @@ Download a support bundle by going to **Help** > **Support Logs**  and select **
 
 ## Logging Levels
 
-Python has a number of [preset logging levels](https://docs.python.org/2/library/logging.html#logging-levels) and allows for custom ones as well. Since logging on the Virtualization Platform uses the `logging` framework, log statements of all levels are supported.
+Python has a number of [preset logging levels](https://docs.python.org/3.8/library/logging.html#logging-levels) and allows for custom ones as well. Since logging on the Virtualization Platform uses the `logging` framework, log statements of all levels are supported.
 
 However, the Virtualization Platform will map all logging levels into three files: `debug.log`, `info.log`, and `error.log` in the following way:
 

--- a/docs/docs/References/Platform_Libraries.md
+++ b/docs/docs/References/Platform_Libraries.md
@@ -71,7 +71,7 @@ stderr | String | Stderr from the command.
 
 ### Examples
 
-Calling bash with an inline command.
+##### Calling bash with an inline command.
 
 ```python
 from dlpx.virtualization import libs
@@ -86,7 +86,7 @@ print response.stdout
 print response.stderr
 ```
 
-Using parameters to construct a bash command.
+##### Using parameters to construct a bash command.
 
 ```python
 from dlpx.virtualization import libs
@@ -98,14 +98,26 @@ command = "mysqldump -u {} -p {}".format(name,port)
 response = libs.run_bash(connection, command)
 ```
 
-Running a bash script that is saved in a directory.
+##### Running a bash script that is saved in a directory.
 
+###### Python 2.7 recommended approach
 ```python
 
  import pkgutil
  from dlpx.virtualization import libs
 
  script_content = pkgutil.get_data('resources', 'get_date.sh')
+
+ # Execute script on remote host
+ response = libs.run_bash(direct_source.connection, script_content)
+```
+###### Python 3.8 recommended approach
+```python
+
+ from importlib import resources
+ from dlpx.virtualization import libs
+
+ script_content = resources.read_text('resources', 'get_date.sh')
 
  # Execute script on remote host
  response = libs.run_bash(direct_source.connection, script_content)

--- a/docs/docs/References/Plugin_Config.md
+++ b/docs/docs/References/Plugin_Config.md
@@ -17,7 +17,7 @@ The name of the file can be specified during the build. By default, the build lo
 |entryPoint|Y|string|A fully qualified Python symbol that points to the `dlpx.virtualization.platform.Plugin` object that defines the plugin.<br><br>It must be in the form `importable.module:object_name` where `importable.module` is in `srcDir`.|
 |manualDiscovery|N|boolean|True if the plugin supports manual discovery of source config objects. The default value is `true`.|
 |pluginType|Y|enum|The ingestion strategy of the plugin. Can be either `STAGED` or `DIRECT`.|
-|language|Y|enum|Must be `PYTHON27`.|
+|language|Y|enum|Must be `PYTHON38`.|
 |defaultLocale|N|enum|The locale to be used by the plugin if the Delphix user does not specify one. Plugin messages will be displayed in this locale by default. The default value is `en-us`.|
 |rootSquashEnabled|N|boolean|This dictates whether "root squash" is enabled on NFS mounts for the plugin (i.e. whether the `root` user on remote hosts has access to the NFS mounts). Setting this to `false` allows processes usually run as `root`, like Docker daemons, access to the NFS mounts. The default value is `true`. This field only applies to Unix hosts.|
 |extendedStartStopHooks|N|boolean|This controls whether the user's pre-start and post-start hooks will run during enable operations (and, likewise, whether pre-stop and post-stop hooks will run during disable operations). The default value is `false`.|
@@ -46,14 +46,13 @@ This is a valid plugin config for the plugin:
 ```yaml
 id: 7cf830f2-82f3-4d5d-a63c-7bbe50c22b32
 name: MongoDB
-version: 2.0.0
 hostTypes:
   - UNIX
 entryPoint: mongo_runner:mongodb
 srcDir: src/
 schemaFile: schema.json
 pluginType: DIRECT
-language: PYTHON27
+language: PYTHON38
 buildNumber: 0.1.0
 ```
 This is a valid plugin config for the plugin with `manualDiscovery` set to `false` and an `externalVersion` set:
@@ -68,7 +67,7 @@ srcDir: src/
 schemaFile: schema.json
 manualDiscovery: false
 pluginType: DIRECT
-language: PYTHON27
+language: PYTHON38
 externalVersion: "MongoDB 1.0"
 buildNumber: "1"
 ```

--- a/docs/docs/References/Version_Compatibility.md
+++ b/docs/docs/References/Version_Compatibility.md
@@ -1,0 +1,26 @@
+# Virtualization SDK Version Compatibility
+
+## Virtualization SDK and Delphix Engine (DE) Compatibility Map
+
+|vSDK Version|Earliest Supported DE Version|Latest Supported DE Version|
+|------------|:---------------------------:|:-------------------------:|
+|4.0.0|6.0.12.0|[Latest Release](https://docs.delphix.com/docs/release-notes/)|
+|3.1.0|6.0.7.0|[Latest Release](https://docs.delphix.com/docs/release-notes/)|
+|3.0.0|6.0.6.0|[Latest Release](https://docs.delphix.com/docs/release-notes/)|
+|2.1.0|6.0.3.0|[Latest Release](https://docs.delphix.com/docs/release-notes/)|
+|2.0.0|6.0.2.0|[Latest Release](https://docs.delphix.com/docs/release-notes/)|
+|1.0.0|6.0.2.0|[Latest Release](https://docs.delphix.com/docs/release-notes/)|
+|0.4.0|5.3.5.0|6.0.1.0|
+
+## Virtualization SDK and Python Compatibility Map
+
+|vSDK Version|Python Version|
+|------------|:------------:|
+|4.0.0|3.8|
+|3.1.0|2.7|
+|3.0.0|2.7|
+|2.1.0|2.7|
+|2.0.0|2.7|
+|1.0.0|2.7|
+|0.4.0|2.7|
+

--- a/docs/docs/Release_Notes/4.0.0/.pages
+++ b/docs/docs/Release_Notes/4.0.0/.pages
@@ -1,0 +1,3 @@
+arrange:
+  - 4.0.0.md
+  - 4.0.0_Breaking_Changes.md

--- a/docs/docs/Release_Notes/4.0.0/4.0.0.md
+++ b/docs/docs/Release_Notes/4.0.0/4.0.0.md
@@ -1,0 +1,11 @@
+# Release - v4.0.0
+
+To install or upgrade the SDK, refer to instructions [here](/Getting_Started.md#installation).
+
+## New & Improved
+
+* Added support for plugins written in Python 3.8.
+
+## Breaking Changes
+
+* The CLI now requires Python 3.8 for installation and usage.

--- a/docs/docs/Release_Notes/4.0.0/4.0.0_Breaking_Changes.md
+++ b/docs/docs/Release_Notes/4.0.0/4.0.0_Breaking_Changes.md
@@ -1,0 +1,4 @@
+# Breaking Changes - v.4.0.0
+
+## New Language Requirement
+The vSDK now requires Python 3.8.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Delphix Virtualization SDK 3.1.0
+site_name: Delphix Virtualization SDK 4.0.0
 theme:
   name: material
   custom_dir: 'material/'


### PR DESCRIPTION
This diff updates the docs to reflect the transition to Python3. Included a new Version Compatibility page for vSDK -> Delphix Engine and vSDK -> Python version mapping. Other changes are mostly updating links and replacing `pkgutil.get_data` with Python 3's `importlib.resources.read_text`, as well as some other small updates.

Also had to update the actions for testing on Python 2.7 as it seems `macos-latest` has now reached a version that doesn't support Python 2.7 at all. Set this subset of tests to run on macos-10.15.

Also replaced references to Jas Sumal with Ryan Fowler as Jas left Delphix awhile back.