### PR TITLE
DLPX-83062 Update engine version to 1.11.16 in develop branch

### DIFF
--- a/tools/src/main/python/dlpx/virtualization/_internal/settings.cfg
+++ b/tools/src/main/python/dlpx/virtualization/_internal/settings.cfg
@@ -20,7 +20,7 @@
 # versions in those packages until they are shipped out of band.
 #
 [General]
-engine_api_version = 1.12.0
+engine_api_version = 1.11.16
 distribution_name = dvp-tools
 package_author = Delphix
 namespace_package = dlpx

--- a/tools/src/test/python/dlpx/virtualization/_internal/conftest.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/conftest.py
@@ -710,7 +710,7 @@ def artifact_content(engine_api, virtual_source_definition,
 
 @pytest.fixture
 def engine_api():
-    return {'type': 'APIVersion', 'major': 1, 'minor': 12, 'micro': 0}
+    return {'type': 'APIVersion', 'major': 1, 'minor': 11, 'micro': 16}
 
 
 @pytest.fixture

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_package_util.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_package_util.py
@@ -18,7 +18,7 @@ class TestPackageUtil:
 
     @staticmethod
     def test_get_engine_api_version():
-        assert package_util.get_engine_api_version_from_settings() == '1.12.0'
+        assert package_util.get_engine_api_version_from_settings() == '1.11.16'
 
     @staticmethod
     def test_get_build_api_version_json():
@@ -35,8 +35,8 @@ class TestPackageUtil:
         engine_api_version = {
             'type': 'APIVersion',
             'major': 1,
-            'minor': 12,
-            'micro': 0
+            'minor': 11,
+            'micro': 16
         }
         assert package_util.get_engine_api_version() == engine_api_version
 


### PR DESCRIPTION
# Context

As the GitFlow is changing for app-gate and qa-gate, develop will now point to latest version of released Delphix Engine API version which is 1.11.16. This will keep develop and master branch in sync.