### PR TITLE
DLPX-84163 Update all the greater than equal to (>=) dependencies in setup.py and requirements.txt files of dvp packages to equal to(==)

### DIFF
--- a/.github/workflows/publish-python-packages.yml
+++ b/.github/workflows/publish-python-packages.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [2.7]
+        python-version: [3.8]
         package: [common, dvp, libs, platform, tools]
 
     steps:

--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -47,6 +47,12 @@ Help() {
   echo "     v${blackColor}      |   ${orangeColor}Verbose mode on           ${blackColor}  |   ${greenColor}sh build_project.sh -t -v${noColor}"
   echo "      ${blackColor}      |   ${orangeColor}                          ${blackColor}  |   ${greenColor}sh build_project.sh -bvt -m tools${noColor}"
   print_separator
+  echo "     c${blackColor}      |   ${orangeColor}Test Coverage mode on     ${blackColor}  |   ${greenColor}sh build_project.sh -t -c${noColor}"
+  echo "      ${blackColor}      |   ${orangeColor}                          ${blackColor}  |   ${greenColor}sh build_project.sh -bct -m tools${noColor}"
+  print_separator
+  echo "     f${blackColor}      |   ${orangeColor}Flake8 validation mode on ${blackColor}  |   ${greenColor}sh build_project.sh -f${noColor}"
+  echo "      ${blackColor}      |   ${orangeColor}                          ${blackColor}  |   ${greenColor}sh build_project.sh -bft -m tools${noColor}"
+  print_separator
   echo "     m${blackColor}      |   ${orangeColor}provide a list of modules.${blackColor}  |   ${greenColor}sh build_project.sh -bt -m common -m libs${noColor}"
   echo "      ${blackColor}      |   ${orangeColor}Valid python modules:     ${blackColor}  |   ${noColor}"
   echo "      ${blackColor}      |   ${orangeColor}  - common                ${blackColor}  |   ${noColor}"

--- a/common/requirements.txt
+++ b/common/requirements.txt
@@ -1,15 +1,7 @@
-bump2version==0.5.11
-contextlib2==0.6.0.post1 ; python_version < '3'
-enum34==1.1.6
-funcsigs==1.0.2 ; python_version < '3.0'
-importlib-metadata==0.23 ; python_version < '3.8'
-more-itertools==5.0.0 ; python_version <= '2.7'
-packaging==19.2
-pathlib2==2.3.5 ; python_version < '3.6'
-pluggy==0.13.0
-py==1.8.0
-pyparsing==2.4.5
-pytest==4.6.11
-scandir==1.10.0 ; python_version < '3.5'
-six==1.13.0
-zipp==0.6.0
+bump2version==1.0.1
+packaging==22.0
+pluggy==1.0.0
+pyparsing==3.0.9
+pytest==7.2.0
+six==1.16.0
+zipp==3.11.0

--- a/common/setup.cfg
+++ b/common/setup.cfg
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2022 by Delphix. All rights reserved.
 #
 
 [metadata]
@@ -12,10 +12,9 @@ long_description_content_type: text/markdown
 classifiers:
     Development Status :: 5 - Production/Stable
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3.8
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
 
 [options]
-requires_python: >=2.7, <=3.8, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, !=3.7.*
+requires_python: >=3.8, <3.9

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,8 @@ import setuptools
 PYTHON_SRC = 'src/main/python'
 
 install_requires = [
-  "dvp-api == 1.7.0",
+    "dvp-api == 1.7.0",
+    "six >= 1.16, < 1.17",
 ]
 
 with open(os.path.join(PYTHON_SRC, 'dlpx/virtualization/common/VERSION')) as version_file:
@@ -15,5 +16,5 @@ setuptools.setup(name='dvp-common',
                  install_requires=install_requires,
                  package_dir={'': PYTHON_SRC},
                  packages=setuptools.find_packages(PYTHON_SRC),
-                 python_requires='>=2.7, <3.9, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, !=3.7.*',
-)
+                 python_requires='>=3.8, <3.9',
+                 )

--- a/dvp/requirements.txt
+++ b/dvp/requirements.txt
@@ -1,14 +1,7 @@
-bump2version==0.5.11
-contextlib2==0.6.0.post1 ; python_version < '3'
-funcsigs==1.0.2 ; python_version < '3.0'
-importlib-metadata==1.3.0 ; python_version < '3.8'
-more-itertools==5.0.0 ; python_version <= '2.7'
-packaging==20.0
-pathlib2==2.3.5 ; python_version < '3'
-pluggy==0.13.1
-py==1.8.1
-pyparsing==2.4.6
-pytest==4.6.11
-scandir==1.10.0 ; python_version < '3.5'
-six==1.13.0
-zipp==0.6.0
+bump2version==1.0.1
+packaging==22.0
+pluggy==1.0.0
+pyparsing==3.0.9
+pytest==7.2.0
+six==1.16.0
+zipp==3.11.0

--- a/dvp/setup.py
+++ b/dvp/setup.py
@@ -7,10 +7,10 @@ with open(os.path.join(PYTHON_SRC, 'dlpx/virtualization/VERSION')) as version_fi
     version = version_file.read().strip()
 
 install_requires = [
-  "dvp-common == {}".format(version),
-  "dvp-libs == {}".format(version),
-  "dvp-platform == {}".format(version),
-  "dvp-tools == {}".format(version)
+    "dvp-common == {}".format(version),
+    "dvp-libs == {}".format(version),
+    "dvp-platform == {}".format(version),
+    "dvp-tools == {}".format(version)
 ]
 
 setuptools.setup(name='dvp',
@@ -19,4 +19,4 @@ setuptools.setup(name='dvp',
                  package_dir={'': PYTHON_SRC},
                  packages=setuptools.find_packages(PYTHON_SRC),
                  python_requires='>=3.8, <3.9',
-)
+                 )

--- a/libs/requirements.txt
+++ b/libs/requirements.txt
@@ -1,17 +1,8 @@
-./../common
-bump2version==0.5.11
-contextlib2==0.6.0.post1 ; python_version < '3'
-enum34==1.1.6
-funcsigs==1.0.2 ; python_version < '3.3'
-importlib-metadata==1.3.0 ; python_version < '3.8'
-mock==3.0.5
-more-itertools==5.0.0 ; python_version <= '2.7'
-packaging==19.2
-pathlib2==2.3.5 ; python_version < '3.6'
-pluggy==0.13.1
-py==1.8.1
-pyparsing==2.4.6
-pytest==4.6.11
-scandir==1.10.0 ; python_version < '3.5'
-six==1.13.0
-zipp==0.6.0
+bump2version==1.0.1
+mock==4.0.3
+packaging==22.0
+pluggy==1.0.0
+pyparsing==3.0.9
+pytest==7.2.0
+six==1.16.0
+zipp==3.11.0

--- a/libs/requirements.txt
+++ b/libs/requirements.txt
@@ -1,3 +1,4 @@
+./../common
 bump2version==1.0.1
 mock==4.0.3
 packaging==22.0

--- a/libs/setup.cfg
+++ b/libs/setup.cfg
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2022 by Delphix. All rights reserved.
 #
 
 [metadata]
@@ -13,10 +13,9 @@ long_description_content_type: text/markdown
 classifiers:
     Development Status :: 5 - Production/Stable
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3.8
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
 
 [options]
-requires_python: >=2.7, <=3.8, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, !=3.7.*
+requires_python: >=3.8, <3.9

--- a/libs/setup.py
+++ b/libs/setup.py
@@ -7,8 +7,9 @@ with open(os.path.join(PYTHON_SRC, 'dlpx/virtualization/libs/VERSION')) as versi
     version = version_file.read().strip()
 
 install_requires = [
-  "dvp-api == 1.7.0",
-  "dvp-common == {}".format(version)
+    "dvp-api == 1.7.0",
+    "dvp-common == {}".format(version),
+    "six >= 1.16, < 1.17",
 ]
 
 setuptools.setup(name='dvp-libs',
@@ -16,5 +17,5 @@ setuptools.setup(name='dvp-libs',
                  install_requires=install_requires,
                  package_dir={'': PYTHON_SRC},
                  packages=setuptools.find_packages(PYTHON_SRC),
-                 python_requires='>=2.7, <3.9, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, !=3.7.*',
-)
+                 python_requires='>=3.8, <3.9',
+                 )

--- a/platform/requirements.txt
+++ b/platform/requirements.txt
@@ -1,16 +1,8 @@
-./../common
-bump2version==0.5.11
-contextlib2==0.6.0.post1 ; python_version < '3'
-funcsigs==1.0.2 ; python_version < '3.3'
-importlib-metadata==1.3.0 ; python_version < '3.8'
-mock==3.0.5
-more-itertools==5.0.0 ; python_version <= '2.7'
-packaging==20.0
-pathlib2==2.3.5 ; python_version < '3'
-pluggy==0.13.1
-py==1.8.1
-pyparsing==2.4.6
-pytest==4.6.10
-scandir==1.10.0 ; python_version < '3.5'
-six==1.13.0
-zipp==0.6.0
+bump2version==1.0.1
+mock==4.0.3
+packaging==22.0
+pluggy==1.0.0
+pyparsing==3.0.9
+pytest==7.2.0
+six==1.16.0
+zipp==3.11.0

--- a/platform/requirements.txt
+++ b/platform/requirements.txt
@@ -1,3 +1,4 @@
+./../common
 bump2version==1.0.1
 mock==4.0.3
 packaging==22.0

--- a/platform/setup.cfg
+++ b/platform/setup.cfg
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2022 by Delphix. All rights reserved.
 #
 
 [metadata]
@@ -13,10 +13,9 @@ long_description_content_type: text/markdown
 classifiers:
     Development Status :: 5 - Production/Stable
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3.8
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
 
 [options]
-requires_python: >=2.7, <=3.8, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, !=3.7.*
+requires_python: >=3.8, <3.9

--- a/platform/setup.py
+++ b/platform/setup.py
@@ -9,7 +9,6 @@ with open(os.path.join(PYTHON_SRC, 'dlpx/virtualization/platform/VERSION')) as v
 install_requires = [
   "dvp-api == 1.7.0",
   "dvp-common == {}".format(version),
-  "enum34;python_version < '3.4'",
 ]
 
 setuptools.setup(name='dvp-platform',

--- a/platform/setup.py
+++ b/platform/setup.py
@@ -7,8 +7,9 @@ with open(os.path.join(PYTHON_SRC, 'dlpx/virtualization/platform/VERSION')) as v
     version = version_file.read().strip()
 
 install_requires = [
-  "dvp-api == 1.7.0",
-  "dvp-common == {}".format(version),
+    "dvp-api == 1.7.0",
+    "dvp-common == {}".format(version),
+    "six >= 1.16, < 1.17",
 ]
 
 setuptools.setup(name='dvp-platform',
@@ -16,5 +17,5 @@ setuptools.setup(name='dvp-platform',
                  install_requires=install_requires,
                  package_dir={'': PYTHON_SRC},
                  packages=setuptools.find_packages(PYTHON_SRC),
-                 python_requires='>=2.7, <3.9, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, !=3.7.*',
-)
+                 python_requires='>=3.8, <3.9',
+                 )

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,33 +1,19 @@
-./../common
-./../libs
-./../platform
-backports.functools-lru-cache==1.6.1 ; python_version < '3.2'
-bump2version==0.5.11
-contextlib2==0.6.0.post1 ; python_version < '3'
-coverage==5.0.2
-entrypoints==0.3
-enum34==1.1.6
-flake8==3.7.9
-funcsigs==1.0.2 ; python_version < '3.3'
-functools32==3.2.3.post2 ; python_version < '3'
-futures==3.3.0 ; python_version < '3.2'
+bump2version==1.0.1
+coverage==6.5.0
+entrypoints==0.4
+flake8==6.0.0
 httpretty==0.9.7
-importlib-metadata==1.3.0 ; python_version < '3.8'
-isort==4.3.21
-mccabe==0.6.1
-mock==3.0.5
-more-itertools==5.0.0
-packaging==20.0
-pathlib2==2.3.5 ; python_version < '3'
-pluggy==0.13.1
-py==1.8.1
-pycodestyle==2.5.0
-pyflakes==2.1.1
-pyparsing==2.4.6
-pytest-cov==2.8.1
-pytest==4.6.11
-scandir==1.10.0 ; python_version < '3.5'
-six==1.13.0
-typing==3.7.4.1 ; python_version < '3.5'
-yapf==0.28
-zipp==0.6.0
+isort==5.11.1
+mccabe==0.7.0
+mock==4.0.3
+more-itertools==9.0.0
+packaging==22.0
+pluggy==1.0.0
+pycodestyle==2.10.0
+pyflakes==3.0.1
+pyparsing==3.0.9
+pytest-cov==4.0.0
+pytest==7.2.0
+six==1.16.0
+yapf==0.32
+zipp==3.11.0

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,3 +1,4 @@
+./../common
 ./../libs
 ./../platform
 bump2version==1.0.1

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -5,7 +5,7 @@ bump2version==1.0.1
 coverage==6.5.0
 entrypoints==0.4
 flake8==6.0.0
-httpretty==0.9.7
+httpretty==1.0.5
 isort==5.11.1
 mccabe==0.7.0
 mock==4.0.3

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,3 +1,5 @@
+./../libs
+./../platform
 bump2version==1.0.1
 coverage==6.5.0
 entrypoints==0.4

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     "jsonschema == 4.17.3",
     "pyyaml == 6",
     "requests == 2.28.1",
-    "httpretty == 0.9.7",
+    "httpretty == 1.0.5",
 ]
 
 setuptools.setup(name='dvp-tools',

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -7,16 +7,24 @@ with open(os.path.join(PYTHON_SRC, 'dlpx/virtualization/_internal/VERSION')) as 
     version = version_file.read().strip()
 
 install_requires = [
+    "attrs >= 22.2, < 22.3",
+    "certifi >= 2022, < 2023",
     "click == 7.1.2",
     "click-configfile == 0.2.3",
-    "dvp-platform == {}".format(version),
+    "configparser >= 5.3, < 5.4",
     "dvp-libs == {}".format(version),
-    "flake8 == 6.0.0",
-    "jinja2 == 3.1.2",
-    "jsonschema == 4.17.3",
-    "pyyaml == 6",
-    "requests == 2.28.1",
-    "httpretty == 1.0.5",
+    "dvp-platform == {}".format(version),
+    "flake8 >= 6.0, < 6.1",
+    "httpretty >= 1.0, < 1.1",
+    "importlib-resources >= 5.10, < 5.11",
+    "jinja2 >= 3.1, < 3.2",
+    "jsonschema >= 4.17, < 4.18",
+    "MarkupSafe >= 2.1, < 2.2",
+    "pkgutil_resolve_name == 1.3.10",
+    "pyyaml >= 6, < 7",
+    "requests >= 2.28, < 2.29",
+    "six >= 1.16, < 1.17",
+    "zipp >= 3.11, < 3.12",
 ]
 
 setuptools.setup(name='dvp-tools',
@@ -25,4 +33,4 @@ setuptools.setup(name='dvp-tools',
                  package_dir={'': PYTHON_SRC},
                  packages=setuptools.find_packages(PYTHON_SRC),
                  python_requires='>=3.8, <3.9',
-)
+                 )

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -6,6 +6,13 @@ PYTHON_SRC = 'src/main/python'
 with open(os.path.join(PYTHON_SRC, 'dlpx/virtualization/_internal/VERSION')) as version_file:
     version = version_file.read().strip()
 
+#
+# Update the dependency using below use cases
+# 1. Dependency version change does not break test cases or have code issues
+#   - Only update the maximum version (<).
+# 2. Dependency version changes break test cases or have code issues
+#   - Update the minimum as well as maximum version along with code changes.
+#
 install_requires = [
     "attrs >= 22.2, < 22.3",
     "certifi >= 2022, < 2023",

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -10,12 +10,12 @@ install_requires = [
     "click == 7.1.2",
     "click-configfile == 0.2.3",
     "dvp-platform == {}".format(version),
-    "enum34 >= 1.1.6",
-    "flake8 >= 3.6",
-    "jinja2 >= 2.10",
-    "jsonschema >= 3",
-    "pyyaml >= 3",
-    "requests >= 2.21.0",
+    "dvp-libs == {}".format(version),
+    "flake8 == 6.0.0",
+    "jinja2 == 3.1.2",
+    "jsonschema == 4.17.3",
+    "pyyaml == 6",
+    "requests == 2.28.1",
     "httpretty == 0.9.7",
 ]
 

--- a/tools/src/main/python/dlpx/virtualization/_internal/plugin_validator.py
+++ b/tools/src/main/python/dlpx/virtualization/_internal/plugin_validator.py
@@ -210,15 +210,15 @@ class PluginValidator:
                                              exclude=[exclude_dir],
                                              quiet=1)
         style_guide.check_files(paths=[src_dir])
-        file_checkers = style_guide._application.file_checker_manager.checkers
+        style_results = style_guide._application.file_checker_manager.results
 
-        for checker in file_checkers:
-            for result in checker.results:
+        for filename, results, _ in style_results:
+            for (error_code, line_number, _, text, _) in results:
                 # From the api code, result is a tuple defined as: error =
                 # (error_code, line_number, column, text, physical_line)
-                if result[0] == 'F821':
-                    msg = "{} on line {} in {}".format(result[3], result[1],
-                                                       checker.filename)
+                if error_code == 'F821':
+                    msg = "{} on line {} in {}".format(text, line_number,
+                                                       filename)
                     warnings['exception'].append(exceptions.UserError(msg))
 
         if warnings and len(warnings) > 0:

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_plugin_validator.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_plugin_validator.py
@@ -3,6 +3,7 @@
 #
 
 import json
+import os
 
 import mock
 import pytest
@@ -69,6 +70,7 @@ class TestPluginValidator:
                               ('1.0.0_HF', None)])
     def test_plugin_version_format(plugin_config_file,
                                    plugin_config_content, expected):
+        message = None
         try:
             validator = PluginValidator.from_config_content(
                 plugin_config_file, plugin_config_content,
@@ -76,7 +78,7 @@ class TestPluginValidator:
             validator.validate_plugin_config()
         except exceptions.SchemaValidationError as err_info:
             message = err_info.message
-            assert expected in message
+        TestPluginValidator.assert_string(expected, message)
 
     @staticmethod
     @mock.patch('os.path.isabs', return_value=False)
@@ -90,6 +92,7 @@ class TestPluginValidator:
          ('staged_plugin:staged', None)])
     def test_plugin_entry_point(plugin_config_file,
                                 plugin_config_content, expected):
+        message = None
         try:
             validator = PluginValidator.from_config_content(
                 plugin_config_file, plugin_config_content,
@@ -97,7 +100,7 @@ class TestPluginValidator:
             validator.validate_plugin_config()
         except exceptions.SchemaValidationError as err_info:
             message = err_info.message
-            assert expected in message
+        TestPluginValidator.assert_string(expected, message)
 
     @staticmethod
     def test_plugin_additional_properties(plugin_config_file,
@@ -105,15 +108,13 @@ class TestPluginValidator:
         # Adding an unknown key
         plugin_config_content['unknown_key'] = 'unknown_value'
 
-        try:
+        with pytest.raises(exceptions.SchemaValidationError) as err_info:
             validator = PluginValidator.from_config_content(
                 plugin_config_file, plugin_config_content,
                 const.PLUGIN_CONFIG_SCHEMA)
             validator.validate_plugin_config()
-        except exceptions.SchemaValidationError as err_info:
-            message = err_info.message
-            assert ("Additional properties are not allowed"
-                    " ('unknown_key' was unexpected)" in message)
+        assert ("Additional properties are not allowed"
+                " ('unknown_key' was unexpected)" in err_info.value.message)
 
     @staticmethod
     @pytest.mark.parametrize('host_types', [['xxx']])
@@ -142,6 +143,7 @@ class TestPluginValidator:
          ('e3b69c61-4c30-44f7-92c0-504c8388b91e', None)])
     def test_plugin_id(plugin_config_file,
                        plugin_config_content, expected):
+        message = None
         try:
             validator = PluginValidator.from_config_content(
                 plugin_config_file, plugin_config_content,
@@ -149,7 +151,7 @@ class TestPluginValidator:
             validator.validate_plugin_config()
         except exceptions.SchemaValidationError as err_info:
             message = err_info.message
-            assert expected in message
+        TestPluginValidator.assert_string(expected, message)
 
     @staticmethod
     @mock.patch('os.path.isabs', return_value=False)
@@ -165,6 +167,7 @@ class TestPluginValidator:
                               ('0.1', None)])
     def test_plugin_build_number_format(plugin_config_file,
                                         plugin_config_content, expected):
+        message = None
         try:
             validator = PluginValidator.from_config_content(
                 plugin_config_file, plugin_config_content,
@@ -172,7 +175,7 @@ class TestPluginValidator:
             validator.validate_plugin_config()
         except exceptions.SchemaValidationError as err_info:
             message = err_info.message
-            assert expected in message
+        TestPluginValidator.assert_string(expected, message)
 
     @staticmethod
     @mock.patch('os.path.isabs', return_value=False)
@@ -182,14 +185,12 @@ class TestPluginValidator:
          ('!lua#toolkit', "'!lua#toolkit' does not match")])
     def test_plugin_lua_name_format(plugin_config_file,
                                     plugin_config_content, expected):
-        try:
+        with pytest.raises(exceptions.SchemaValidationError) as err_info:
             validator = PluginValidator.from_config_content(
                 plugin_config_file, plugin_config_content,
                 const.PLUGIN_CONFIG_SCHEMA)
             validator.validate_plugin_config()
-        except exceptions.SchemaValidationError as err_info:
-            message = err_info.message
-            assert expected in message
+        assert expected in err_info.value.message
 
     @staticmethod
     @mock.patch('os.path.isabs', return_value=False)
@@ -200,39 +201,56 @@ class TestPluginValidator:
     def test_plugin_minimum_lua_version_format(plugin_config_file,
                                                plugin_config_content,
                                                expected):
-        try:
+        with pytest.raises(exceptions.SchemaValidationError) as err_info:
             validator = PluginValidator.from_config_content(
                 plugin_config_file, plugin_config_content,
                 const.PLUGIN_CONFIG_SCHEMA)
             validator.validate_plugin_config()
-        except exceptions.SchemaValidationError as err_info:
-            message = err_info.message
-            assert expected in message
+        assert expected in err_info.value.message
 
     @staticmethod
     @pytest.mark.parametrize('minimum_lua_version', [None])
     def test_plugin_lua_name_without_minimum_lua_version(
             plugin_config_file, plugin_config_content):
-        try:
+        with pytest.raises(exceptions.ValidationFailedError) as err_info:
             validator = PluginValidator.from_config_content(
                 plugin_config_file, plugin_config_content,
                 const.PLUGIN_CONFIG_SCHEMA)
             validator.validate_plugin_config()
-        except exceptions.ValidationFailedError as err_info:
-            message = err_info.message
-            assert ('Failed to process property "luaName" without '
-                    '"minimumLuaVersion" set in the plugin config.' in message)
+        assert ('Failed to process property "luaName" without "minimumLuaVersion"'
+                ' set in the plugin config.' in err_info.value.message)
 
     @staticmethod
     @pytest.mark.parametrize('lua_name', [None])
     def test_plugin_minimum_lua_version_without_lua_name(
             plugin_config_file, plugin_config_content):
-        try:
+        with pytest.raises(exceptions.ValidationFailedError) as err_info:
             validator = PluginValidator.from_config_content(
                 plugin_config_file, plugin_config_content,
                 const.PLUGIN_CONFIG_SCHEMA)
             validator.validate_plugin_config()
-        except exceptions.ValidationFailedError as err_info:
-            message = err_info.message
-            assert ('Failed to process property "minimumLuaVersion" without '
-                    '"luaName" set in the plugin config.' in message)
+        assert ('Failed to process property "minimumLuaVersion" without '
+                '"luaName" set in the plugin config.' in err_info.value.message)
+
+    @staticmethod
+    def test_undefined_name_validation(plugin_config_file, plugin_config_content):
+        src_dir = plugin_config_content['srcDir']
+        undefined_name_file = os.path.join(src_dir, 'undefined_name.py')
+        with open(undefined_name_file, 'w') as f:
+            f.write('@directplugin.discovery.repository()'
+                    '\ndef repository_discovery(source_connection):'
+                    '\n\treturn None\n\n')
+        with pytest.raises(exceptions.ValidationFailedError) as err_info:
+            validator = PluginValidator.from_config_content(
+                plugin_config_file, plugin_config_content,
+                const.PLUGIN_CONFIG_SCHEMA)
+            validator.validate_plugin_config()
+        assert ('undefined name \'directplugin\' on line 1 '
+                'in {}'.format(undefined_name_file) in err_info.value.message)
+
+    @staticmethod
+    def assert_string(expected_string, actual_string):
+        if expected_string:
+            assert expected_string in actual_string
+        else:
+            assert actual_string is None


### PR DESCRIPTION
### Background

There are around 40 PRs opened by dependentBot to bump up the dependencies version. Also, some dependencies in our setup.py uses `>=` dependencies for example `flake8 >= 3.6` which can cause some unknown errors in case dependencies releases a new version.

### Problem

Recently, flake8 released 6.0.0 version which started causing `dvp build` to fail with `'Manager' object has no attribute 'checkers'`, as flake8 6.0.0 has made changes to manager package.

### Evaluation

The exact cause of the issue is `plugin_validator.py` in `tools` package (line no. 213) where we try to access `checkers` object @`style_guide._application.file_checker_manager.checkers`.

As flake8 6.0.0 has removed `checkers` and started using `result` object, the issue occurred.

### Solution
1. Change all `>=` to `>=, <` or `==` in setup.py files of all packages.
2. Use flake8 == 6.0.0 and update `plugin_validator.py` to sync with flake8 changes.
3. Updated all the dependencies to latest version as required in requirements.txt files.
    - bump2version 0.5.11 -> 1.0.1 for common, dvp, libs, platform, tools
    - packaging 19.2 -> 22.0 for common, dvp, libs, platform, tools
    - pluggy 0.13.0 -> 1.0.0 for common, dvp, libs, platform, tools
    - pyparsing 2.4.5 -> 3.0.9 for common, dvp, libs, platform, tools
    - pytest 4.6.11 -> 7.2.0 for common, dvp, libs, platform, tools
    - six 1.13.0 -> 1.16.0 for common, dvp, libs, platform, tools
    - zipp 0.6.0 -> 3.11.0 for common, dvp, libs, platform, tools
    - mock 3.0.5 -> 4.0.3 for libs, platform, tools
    - coverage 5.0.2 -> 6.5.0 for tools
    - entrypoints 0.3 -> 0.4 for tools
    - flake8 3.7.9 -> 6.0.0 for tools
    - httpretty 0.9.7 -> 1.0.5 for tools
    - isort 4.3.21 -> 5.11.1 for tools
    - mccabe 0.6.1 -> 0.7.0 for tools
    - more-itertools 5.0.0 -> 9.0.0 for tools
    - pycodestyle 2.5.0 -> 2.10.0 for tools
    - pyflakes 2.1.1 -> 3.0.1 for tools
    - pytest-cov 2.8.1 -> 4.0.0 for tools
    - yapf 0.28 -> 0.32 for tools
4. Removed older and unused dependencies.
    - All dependencies with python_version less than 3.8 have been removed.
    - enum34 and py have been removed as they were not being used anywhere in the code.

### Testing Done
#### appdata_python_samples
- http://selfservice.jenkins.delphix.com/job/blackbox-self-service/62929

#### appdata_basic
- [Appdata Python nix_direct_python - CentOS 8.0](http://selfservice.jenkins.delphix.com/job/blackbox-self-service/63004)
- [Appdata Python nix_staged_python - RHEL 7.9](http://selfservice.jenkins.delphix.com/job/blackbox-self-service/63005)
- Appdata Python win_direct_python - Win 2016 - Facing some issues with machines for this run. Tested the same without the [changes](http://selfservice.jenkins.delphix.com/job/blackbox-self-service/64480/consoleFull) and got the same errors.
- [Appdata Python win_staged_python - Win 2012](http://selfservice.jenkins.delphix.com/job/blackbox-self-service/63007)

#### virtualization_sdk
- [Nix direct appdata python plugin](http://selfservice.jenkins.delphix.com/job/blackbox-self-service/62930)
- [Nix staged appdata python plugin](http://selfservice.jenkins.delphix.com/job/blackbox-self-service/62931)
- [Windows direct appdata python plugin](http://selfservice.jenkins.delphix.com/job/blackbox-self-service/62932)
- [Windows staged appdata python plugin](http://selfservice.jenkins.delphix.com/job/blackbox-self-service/62933)
- [Windows staged default plugin built on Windows 10 Pro SDK host](http://selfservice.jenkins.delphix.com/job/blackbox-self-service/62952)

### Bonus
- PRs that will be closed
    - Bump pytest-cov [388](https://github.com/delphix/virtualization-sdk/pull/388)
    - Bump six [384](https://github.com/delphix/virtualization-sdk/pull/384), [383](https://github.com/delphix/virtualization-sdk/pull/383), [381](https://github.com/delphix/virtualization-sdk/pull/381), [379](https://github.com/delphix/virtualization-sdk/pull/379), [378](https://github.com/delphix/virtualization-sdk/pull/378)
    - Bump flake8 [380](https://github.com/delphix/virtualization-sdk/pull/380)
    - Bump pyflakes [376](https://github.com/delphix/virtualization-sdk/pull/376)
    - Bump yafp [375](https://github.com/delphix/virtualization-sdk/pull/375)
    - Bump pycodestyle [374](https://github.com/delphix/virtualization-sdk/pull/374)
    - Bump py [372](https://github.com/delphix/virtualization-sdk/pull/372), [368](https://github.com/delphix/virtualization-sdk/pull/368), [367](https://github.com/delphix/virtualization-sdk/pull/367), [366](https://github.com/delphix/virtualization-sdk/pull/366), [365](https://github.com/delphix/virtualization-sdk/pull/365), [364](https://github.com/delphix/virtualization-sdk/pull/364), [300](https://github.com/delphix/virtualization-sdk/pull/300), [296](https://github.com/delphix/virtualization-sdk/pull/296), [295](https://github.com/delphix/virtualization-sdk/pull/295), [294](https://github.com/delphix/virtualization-sdk/pull/294)
    - Bump enum34 [354](https://github.com/delphix/virtualization-sdk/pull/354), [352](https://github.com/delphix/virtualization-sdk/pull/352), [162](https://github.com/delphix/virtualization-sdk/pull/162)
    - Bump coverage [353](https://github.com/delphix/virtualization-sdk/pull/353)
    - Bump packaging [329](https://github.com/delphix/virtualization-sdk/pull/329), [328](https://github.com/delphix/virtualization-sdk/pull/328), [327](https://github.com/delphix/virtualization-sdk/pull/327), [324](https://github.com/delphix/virtualization-sdk/pull/324)
    - Bump pytest [189](https://github.com/delphix/virtualization-sdk/pull/189)
    - Bump zipp [161](https://github.com/delphix/virtualization-sdk/pull/161), [142](https://github.com/delphix/virtualization-sdk/pull/142), [139](https://github.com/delphix/virtualization-sdk/pull/139), [131](https://github.com/delphix/virtualization-sdk/pull/131), [130](https://github.com/delphix/virtualization-sdk/pull/130)
    - Bump pluggy [155](https://github.com/delphix/virtualization-sdk/pull/155)
    - Bump pyparsing [151](https://github.com/delphix/virtualization-sdk/pull/151), [145](https://github.com/delphix/virtualization-sdk/pull/145), [138](https://github.com/delphix/virtualization-sdk/pull/138), [137](https://github.com/delphix/virtualization-sdk/pull/137), [133](https://github.com/delphix/virtualization-sdk/pull/133)
- dependentBot Security alerts will be resolved once changes are merged. 


### Dependency Tree for dvp 4.0.5 install
<img width="1620" alt="dvp4 0 5_Dependency_tree" src="https://user-images.githubusercontent.com/45626610/210538029-b7f85b02-a26c-4501-ba8d-c75eeed9defc.png">

### Dependency Tree for local changes install
<img width="862" alt="Changes_dependency_tree" src="https://user-images.githubusercontent.com/45626610/210538044-f4eae52c-52d0-457b-918c-9a7a21500241.png">

### Diff of Pip Freeze
<img width="1910" alt="PipFreezeDiff" src="https://user-images.githubusercontent.com/45626610/210538264-24b44d53-013d-46e5-8f90-09ea6410a4df.png">

