### PR TITLE
CP-10628 Release Jython Removal Documentation changes.

### DIFF
--- a/docs/docs/References/Version_Compatibility.md
+++ b/docs/docs/References/Version_Compatibility.md
@@ -11,7 +11,7 @@
 | [3.0.0](../Release_Notes/3.0.0/3.0.0.md) |            6.0.6.0            | [Latest Release](https://cd.delphix.com/docs/latest/new-features) |
 | [2.1.0](../Release_Notes/2.1.0/2.1.0.md) |            6.0.3.0            | [Latest Release](https://cd.delphix.com/docs/latest/new-features) |
 | [2.0.0](../Release_Notes/2.0.0/2.0.0.md) |            6.0.2.0            | [Latest Release](https://cd.delphix.com/docs/latest/new-features) |
-| [1.0.0](../Release_Notes/1.0.0/1.0.0.md) |            6.0.2.0            | [Latest Release](https://cd.delphix.com/docs/latest/new-features) |
+| [1.0.0](../Release_Notes/1.0.0/1.0.0.md) |            6.0.2.0            |                             14.0.0.0                              |
 | [0.4.0](../Release_Notes/0.4.0/0.4.0.md) |            5.3.5.0            |                              6.0.1.0                              |
 
 ## Virtualization SDK and Python Compatibility Map


### PR DESCRIPTION
Release Jython Removal documentation changes. 
Raised after comparing master to docs branch. A clean cherry pick.