### PR TITLE
CP-12230 DVP Record size validation changes for setting ZFS record size

### DIFF
--- a/tools/src/main/python/dlpx/virtualization/_internal/validation_schemas/plugin_schema.json
+++ b/tools/src/main/python/dlpx/virtualization/_internal/validation_schemas/plugin_schema.json
@@ -166,6 +166,15 @@
        "required": ["nameField", "identityFields"],
        "nameField": { "type": "string" },
        "identityFields": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+    },
+    "recordSizeObject": {
+      "type": "object",
+      "properties": {
+          "properties": {
+              "properties": {
+              "recordSizeInKB" : {"properties": {"type": {"enum" : ["integer"]}}}}
+          }
+      }
     }
   },
   "type": "object",
@@ -200,10 +209,24 @@
       ]
     },
     "virtualSourceDefinition": {
-      "$ref": "#/definitions/jsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/jsonSchema"
+        },
+        {
+          "$ref": "#/definitions/recordSizeObject"
+        }
+      ]
     },
     "linkedSourceDefinition": {
-      "$ref": "#/definitions/jsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/jsonSchema"
+        },
+        {
+          "$ref": "#/definitions/recordSizeObject"
+        }
+      ]
     },
     "snapshotDefinition": {
       "$ref": "#/definitions/jsonSchema"

--- a/tools/src/test/python/dlpx/virtualization/_internal/test_schema_validator.py
+++ b/tools/src/test/python/dlpx/virtualization/_internal/test_schema_validator.py
@@ -356,3 +356,56 @@ class TestSchemaValidator:
         message = err_info.value.message
         assert ("'strings' is not valid under any of the given schemas"
                 in message)
+
+    @staticmethod
+    @pytest.mark.parametrize('linked_source_definition',
+                             [{
+                                 'type': 'object',
+                                 'additionalProperties': False,
+                                 'properties': {
+                                     'recordSizeInKB': {
+                                         'type': 'string'
+                                     }
+                                 }
+                             }])
+    def test_bad_recordSizeInKB_type_string(schema_file):
+        with pytest.raises(exceptions.SchemaValidationError) as err_info:
+            validator = SchemaValidator(schema_file, const.PLUGIN_SCHEMA)
+            validator.validate()
+
+        message = err_info.value.message
+        assert "'string' is not one of ['integer']" in message
+
+    @staticmethod
+    @pytest.mark.parametrize('virtual_source_definition',
+                             [{
+                                 'type': 'object',
+                                 'additionalProperties': False,
+                                 'properties': {
+                                     'recordSizeInKB': {
+                                         'type': 'array'
+                                     }
+                                 }
+                             }])
+    def test_bad_recordSizeInKB_type_array_virtual(schema_file):
+        with pytest.raises(exceptions.SchemaValidationError) as err_info:
+            validator = SchemaValidator(schema_file, const.PLUGIN_SCHEMA)
+            validator.validate()
+
+        message = err_info.value.message
+        assert "'array' is not one of ['integer']" in message
+
+    @staticmethod
+    @pytest.mark.parametrize('virtual_source_definition',
+                             [{
+                                 'type': 'object',
+                                 'additionalProperties': False,
+                                 'properties': {
+                                     'recordSizeInKB': {
+                                         'type': 'integer'
+                                     }
+                                 }
+                             }])
+    def test_recordSizeInKB_type_virtual(schema_file):
+        validator = SchemaValidator(schema_file, const.PLUGIN_SCHEMA)
+        validator.validate()


### PR DESCRIPTION
<!--
### Background
Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
-->
### Problem
DVP Record size schema validation changes for setting ZFS record size
[CP-12230](https://perforce.atlassian.net/browse/CP-12230)

<!--
### Evaluation
If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
-->
### Solution
Added schema validation in plugin_schema.json to check if the field "recordSizeInKB" is of type "integer".

Explanation of the change:

Here in this case the normal validation like below won't work :
`"recordSizeInKB": { 
      "type" : "integer" 
    }`

In this case, we need to retrieve the properties of recordSizeInKB to get the type and then validate it.

- In order to validate if the field "recordSizeInKB" is of type "integer", we have to first retrieve the "properties" field of "linkedSourceDefinition" and "virtualSourceDefinition". This is because the "recordSizeInKB" field needs to be listed within the "properties" field of "linkedSourceDefinition" and "virtualSourceDefinition".
- Once the "properties" field is retrieved, then we need to get the properties of the "recordSizeInKB" to get the "type".
- We have checked the string value of "type" field has to be "integer".

### Testing Done
**Manual:**
Executed  **dvp --verbose build --dev** for correct schema for both linkedSourceDefinition and virtualSourceDefinition.
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/ebdb4012-0c4a-4628-bfb8-4413d661ba53" />
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/fc4b0fdc-7ce2-4af5-b4d7-f298ea84f983" />

Executed  **dvp --verbose build --dev** for inavlid schema for both linkedSourceDefinition and virtualSourceDefinition.
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/34c9d395-5542-48ce-8eba-b764c4331dea" />
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/7cd2fbe2-bbd1-4738-af87-8f77d85f5747" />

Executed  **dvp --verbose build --dev** for schema without "recordSizeInKB" field in schema.
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/f041c032-bb85-406c-9c24-72f7aa408ac7" />


**Unit test:**
<img width="1728" alt="Screenshot 2025-04-01 at 9 52 01 AM" src="https://github.com/user-attachments/assets/6a123a38-5a1e-4b75-9892-1b3add73f803" />
Unit test execution after adding new test cases :
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/30d563ff-d64b-40c7-b7d2-7ab8f78fdf3e" />


**Blackbox tests:**
[virtualization_sdk APPDATA_SDK_UBUNTU20_DIRECT_RHEL79](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/169074/)
[virtualization_sdk APPDATA_SDK_WIN10_STAGED_WIN2019](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/169088/)

<!--
### Implementation
Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
-->
<!--
### Notes to Reviewers
Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
-->
<!--
### Deployment Plan
Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
-->
<!--
### Future Work
Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
-->
<!--
### Bonus
Provide a description of any extra problems you have solved in this pull
request.
-->
