### PR TITLE
DLPXDOC-3433 Typo in instructions for virtualization sdk docs

### DIFF
--- a/docs/docs/Getting_Started.md
+++ b/docs/docs/Getting_Started.md
@@ -3,7 +3,7 @@ The Virtualization SDK is a Python package on [PyPI](https://pypi.org/project/dv
 
 The SDK consists of three parts:
 
-- The `dlpx.virtulization.platform` module
+- The `dlpx.virtualization.platform` module
 - The `dlpx.virtualization.libs` module
 - A CLI
 


### PR DESCRIPTION
Fixes a typo in the property name, correcting `dlpx.virtulization.platform` to `dlpx.virtualization.platform`

**UI Preview:**

Current: https://developer.delphix.com/Getting_Started/

After Change: https://vimleshmishra.github.io/virtualization-sdk/Getting_Started/

