### PR TITLE
DLPX-97338 depbump: bump pytest from 9.0.2 to 9.0.3 (consolidates 9 PRs)

### DIFF
--- a/common/requirements.txt
+++ b/common/requirements.txt
@@ -2,6 +2,6 @@ bump2version==1.0.1
 packaging==26.0
 pluggy==1.6.0
 pyparsing==3.3.2
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 zipp==3.23.0

--- a/dvp/requirements.txt
+++ b/dvp/requirements.txt
@@ -2,6 +2,6 @@ bump2version==1.0.1
 packaging==26.0
 pluggy==1.6.0
 pyparsing==3.3.2
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 zipp==3.23.0

--- a/libs/requirements.txt
+++ b/libs/requirements.txt
@@ -4,6 +4,6 @@ mock==5.2.0
 packaging==26.0
 pluggy==1.6.0
 pyparsing==3.3.2
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 zipp==3.23.0

--- a/platform/requirements.txt
+++ b/platform/requirements.txt
@@ -4,6 +4,6 @@ mock==5.2.0
 packaging==26.0
 pluggy==1.6.0
 pyparsing==3.3.2
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 zipp==3.23.0

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -16,7 +16,7 @@ pycodestyle==2.14.0
 pyflakes==3.4.0
 pyparsing==3.3.2
 pytest-cov==7.1.0
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 yapf==0.43.0
 zipp==3.23.0


### PR DESCRIPTION
# DLPX-97338 depbump: bump pytest from 9.0.2 to 9.0.3

> Auto-generated by **depbump**. Tracked in [DLPX-97338](https://perforce.atlassian.net/browse/DLPX-97338).

## TL;DR

Consolidated **9 stale Dependabot PRs** for pytest across all 5 modules into one PR. Bumped from **9.0.2 → 9.0.3** (latest within current major). **762 tests pass before AND after, 0 install errors, 0 transitive dep moves.** One CVE patched in this range (GHSA-6w46-j5rx-g56g); vSDK is exposed via 156 tmpdir / tmp_path fixture call sites — fix is recommended.

## Risk tier: **MEDIUM**

✅ depbump verified: build passes pre/post-change, smoke plugin built clean, flake8 clean, CVE is medium-severity, no breaking changes. Eligible for `merge_ready`.

## JIRA tracking

- **[DLPX-97338](https://perforce.atlassian.net/browse/DLPX-97338)** — created by depbump before this PR

## Manifests affected (5)

- `common/requirements.txt`: pytest 9.0.2 → 9.0.3
- `libs/requirements.txt`: pytest 9.0.2 → 9.0.3
- `platform/requirements.txt`: pytest 9.0.2 → 9.0.3
- `tools/requirements.txt`: pytest 9.0.2 → 9.0.3
- `dvp/requirements.txt`: pytest 9.0.2 → 9.0.3

## Source PRs consolidated (9)

depbump does not close these. Once this PR merges, Dependabot auto-closes them on next scan.

- #634, #635, #636, #637 (~42 days old)
- #641, #645, #648, #653, #655 (~25 days old)

## CVE findings (1)

### GHSA-6w46-j5rx-g56g · CVE-2025-71176 · CVSS medium

- **Fixed in:** pytest 9.0.3
- **Summary:** pytest has vulnerable tmpdir handling
- **Description:** pytest through 9.0.2 on UNIX relies on directories with the `/tmp/pytest-of-{user}` name pattern, which allows local users to cause a denial of service or possibly gain privileges.
- **Your usage:** 🟡 **EXPOSED via pytest fixtures** — 156 call sites of `tmpdir` / `tmp_path` across `common/src`, `libs/src`, `platform/src`, `tools/src`, `dvp/src`.

## Commit breakdown (10 commits between 9.0.2 and 9.0.3)

- 1 security/CVE fix (CVE-2025-71176)
- 4 bug fixes
- 1 docs
- 4 merge / patchback commits

No breaking changes detected.

## Build verification

| Phase | Result | Summary |
|---|---|---|
| Baseline (pre-change) | ✅ PASS | 762 tests passed across 5 modules |
| Post-change | ✅ PASS | 762 tests passed (same suite) |

### Installed package changes (`pip freeze` diff)

```diff
- pytest==9.0.2
+ pytest==9.0.3
```

**1 explicit + 0 transitive** changes — clean patch bump.

## Additional automations

### Pre-push
- ✅ `sh bin/build_project.sh -f` — flake8 0 issues across 5 modules
- ✅ `sh bin/smoke_plugin_build.sh` — dvp init + dvp build --dev → artifact.json 1.11 MB

### Post-push
- ✅ `git blackbox …` → tracking URL: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/217529/

---

*Generated by depbump · policy: latest-minor-within-major*

