### PR TITLE
DLPX-97344 depbump: bump pytest from 9.0.2 to 9.0.3 (consolidates 9 PRs)

### DIFF
--- a/common/requirements.txt
+++ b/common/requirements.txt
@@ -2,6 +2,6 @@ bump2version==1.0.1
 packaging==26.0
 pluggy==1.6.0
 pyparsing==3.3.2
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 zipp==3.23.0

--- a/dvp/requirements.txt
+++ b/dvp/requirements.txt
@@ -2,6 +2,6 @@ bump2version==1.0.1
 packaging==26.0
 pluggy==1.6.0
 pyparsing==3.3.2
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 zipp==3.23.0

--- a/libs/requirements.txt
+++ b/libs/requirements.txt
@@ -4,6 +4,6 @@ mock==5.2.0
 packaging==26.0
 pluggy==1.6.0
 pyparsing==3.3.2
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 zipp==3.23.0

--- a/platform/requirements.txt
+++ b/platform/requirements.txt
@@ -4,6 +4,6 @@ mock==5.2.0
 packaging==26.0
 pluggy==1.6.0
 pyparsing==3.3.2
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 zipp==3.23.0

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -16,7 +16,7 @@ pycodestyle==2.14.0
 pyflakes==3.4.0
 pyparsing==3.3.2
 pytest-cov==7.1.0
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 yapf==0.43.0
 zipp==3.23.0


### PR DESCRIPTION
## TL;DR

Consolidates **9 open Dependabot PRs** bumping `pytest 9.0.2 → 9.0.3` across all 5 vSDK modules (`common`, `libs`, `platform`, `tools`, `dvp`) into a single change. Empirically verified: baseline + post-change builds both GREEN with identical test counts (**762 passed, 1 skipped**); flake8 and end-to-end SDK smoke (`dvp init` + `dvp build` → `artifact.json`) both pass. Upstream contains 47 commits including a security fix for **CVE-2025-71176** (insecure-tmpdir TOCTOU) — the vulnerable code path is reached via the `tmpdir` fixture used by the `tools` test suite, but exploitability is LOW (test-only, requires local attacker on shared multi-user system). Risk tier: **LOW**.

## Risk tier: LOW

## CVE findings

- **CVE-2025-71176** (no GHSA assigned yet)
  - Fixed in: pytest 9.0.3 (commit `ddee02a`, PR pytest-dev/pytest#14343)
  - Vulnerable code: `_pytest.tmpdir.TempPathFactory.getbasetemp()` — followed symlinks on the `/tmp/pytest-of-<user>` directory, enabling a symlink-swapping TOCTOU attack
  - Fix: stop following symlinks; reject if root tmpdir is a symlink
  - **Your usage:** **CALLED** — the `tools` module's test suite uses the `tmpdir` fixture extensively (32+ uses in `tools/src/test/python/dlpx/virtualization/_internal/conftest.py`, plus `test_file_util.py` (12), `test_plugin_dependency_util.py` (21), `test_templates.py` (3))
  - **Risk: LOW** — pytest is a test-only dependency, not shipped in any vSDK runtime artifact. The vulnerability requires a local attacker on the same machine to pre-create `/tmp/pytest-of-<victim>` as a symlink before the victim runs pytest; not exploitable in single-tenant CI runners or single-user dev workstations. Still worth picking up the fix.

## Commit breakdown (47 commits, pytest 9.0.2 → 9.0.3)

- **1 security/CVE fix**: CVE-2025-71176 (PR #14343 + backport #14363)
- **5 bug fixes**:
  - `exceptiongroup` traceback no longer crashes when only hidden frames present (#14025/#14045)
  - Better error when blocking conftest files via `-p` (#14018/#14074)
  - `pytest.approx` correctly handles Mapping key order (#13815/#14142)
  - `subtests` handles non-string messages consistently (#14196/#14199)
  - *(Note: `assertrepr_compare` dict-insertion-order fix #14050/#14193 was backported then reverted in #14366; net effect for 9.0.3 is no behavior change here.)*
- **1 feature**: `xfail` default (PR #14106 + backport #14107) — small surface change
- **~40 docs / CI / refactor / test-only**: sphinx pin, capture-fixture doc clarifications, training info, ~75 typo fixes, junit-codecov upload, dependabot action bump, etc.

No breaking changes that affected the vSDK build (verified empirically — see below).

## Build verification

| Phase | Command | Result |
|---|---|---|
| Baseline (pytest 9.0.2) | `sh bin/build_project.sh -bt` | ✓ 762 passed, 1 skipped |
| Post-change (pytest 9.0.3) | `sh bin/build_project.sh -bt` | ✓ 762 passed, 1 skipped |

Per-module test counts (both phases identical):

| Module | Tests |
|---|---|
| common | 37 passed |
| libs | 56 passed |
| platform | 282 passed |
| tools | 386 passed, 1 skipped |
| dvp | 1 passed |

### Pip freeze diff (baseline → post-change)

```
< pytest==9.0.2
> pytest==9.0.3
```

Single line of change — no transitive dependency bumps were pulled in.

## Additional automations

| Check | Command | Result |
|---|---|---|
| Lint | `sh bin/build_project.sh -f` | ✓ pass (warnings only, exit 0) |
| SDK smoke | `sh bin/smoke_plugin_build.sh` | ✓ pass — `dvp init` + `dvp build --dev` → `artifact.json` (1,167,546 bytes) |

## Post-push automation

| Check | Result |
|---|---|
| Delphix blackbox QA (`APPDATA_SDK_UBUNTU20_STAGED_CENTOS73`) | ✓ triggered — https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/217600/ |

## Manifests affected (5)

- `common/requirements.txt`: pytest 9.0.2 → 9.0.3
- `libs/requirements.txt`: pytest 9.0.2 → 9.0.3
- `platform/requirements.txt`: pytest 9.0.2 → 9.0.3
- `tools/requirements.txt`: pytest 9.0.2 → 9.0.3
- `dvp/requirements.txt`: pytest 9.0.2 → 9.0.3

## Source PRs (will auto-close once this merges)

- #655 — Bump pytest from 9.0.2 to 9.0.3 in /tools
- #653 — Bump pytest from 9.0.2 to 9.0.3 in /common
- #648 — Bump pytest from 9.0.2 to 9.0.3 in /libs
- #645 — Bump pytest from 9.0.2 to 9.0.3 in /dvp
- #641 — Bump pytest from 9.0.2 to 9.0.3 in /platform
- #637 — Bump pytest from 9.0.2 to 9.0.3 in /platform (duplicate)
- #636 — Bump pytest from 9.0.2 to 9.0.3 in /libs (duplicate)
- #635 — Bump pytest from 9.0.2 to 9.0.3 in /dvp (duplicate)
- #634 — Bump pytest from 9.0.2 to 9.0.3 in /common (duplicate)

## Version note

Source PRs proposed `pytest 9.0.3`. depbump resolved to `9.0.3` (policy: `latest-minor-within-major`) — currently the latest pytest release; no further upgrade available within the 9.x major.

## JIRA

[DLPX-97344](https://perforce.atlassian.net/browse/DLPX-97344)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/depbump`
