### PR TITLE
DLPX-97348 depbump: bump pytest from 9.0.2 to 9.0.3 (consolidates 9 PRs)

### DIFF
--- a/common/requirements.txt
+++ b/common/requirements.txt
@@ -2,6 +2,6 @@ bump2version==1.0.1
 packaging==26.0
 pluggy==1.6.0
 pyparsing==3.3.2
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 zipp==3.23.0

--- a/dvp/requirements.txt
+++ b/dvp/requirements.txt
@@ -2,6 +2,6 @@ bump2version==1.0.1
 packaging==26.0
 pluggy==1.6.0
 pyparsing==3.3.2
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 zipp==3.23.0

--- a/libs/requirements.txt
+++ b/libs/requirements.txt
@@ -4,6 +4,6 @@ mock==5.2.0
 packaging==26.0
 pluggy==1.6.0
 pyparsing==3.3.2
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 zipp==3.23.0

--- a/platform/requirements.txt
+++ b/platform/requirements.txt
@@ -4,6 +4,6 @@ mock==5.2.0
 packaging==26.0
 pluggy==1.6.0
 pyparsing==3.3.2
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 zipp==3.23.0

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -16,7 +16,7 @@ pycodestyle==2.14.0
 pyflakes==3.4.0
 pyparsing==3.3.2
 pytest-cov==7.1.0
-pytest==9.0.2
+pytest==9.0.3
 six==1.17.0
 yapf==0.43.0
 zipp==3.23.0


### PR DESCRIPTION
## TL;DR

This PR consolidates **9 open Dependabot PRs** that all bump `pytest` from `9.0.2` → `9.0.3` across the 5 module manifests into a single change. The bump pulls in **CVE-2025-71176** (CVSS 6.8 MEDIUM — insecure tmpdir TOCTOU). All 47 upstream commits in the range have been classified; consumer call sites for the patched code path are **exclusively in test code**. Baseline + post-change builds both pass and the pip-freeze diff contains only the explicit `pytest` pin change (no transitive bumps).

**Risk tier: LOW** — `merge_ready` applied.

JIRA: [DLPX-97348](https://perforce.atlassian.net/browse/DLPX-97348)

---

## Version transition

| | |
|---|---|
| Dependency | `pytest` |
| From | `9.0.2` |
| To (resolved) | `9.0.3` |
| Source PR target | `9.0.3` (matches resolved) |
| Policy | `latest-minor-within-major` (per `.depbump.md`) |
| Modules affected | all 5 (`common`, `libs`, `platform`, `tools`, `dvp`) |

## CVE findings

**[GHSA-6w46-j5rx-g56g](https://github.com/pytest-dev/pytest/security/advisories/GHSA-6w46-j5rx-g56g) / CVE-2025-71176** — CVSS **6.8 MEDIUM** (`AV:L/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L`)

> *pytest through 9.0.2 on UNIX relies on directories with the `/tmp/pytest-of-{user}` name pattern, which allows local users to cause a denial of service or possibly gain privileges.*

- **Vulnerable versions:** `< 9.0.3`
- **Fixed in:** `9.0.3`
- **Patched function:** `TempPathFactory.getbasetemp()` in `src/_pytest/tmpdir.py` (stops following symlinks; rejects if rootdir is a symlink, closes TOCTOU window between `stat` and `chmod`)
- **Consumer call sites for affected fixture chain (`tmp_path`, `tmp_path_factory`, `tmpdir`):**
  - `tools/src/test/python/.../test_templates.py` — `tmp_path_factory` *(test code)*
  - `tools/src/test/python/.../test_file_util.py` — `tmp_path` *(test code)*
  - `tools/src/test/python/.../test_build.py` — `tmpdir` *(test code)*
  - **Note:** `tools/src/main/.../file_util.py:158:def tmpdir()` is a name-collision — it's the consumer's own helper function, **not** pytest's fixture, and does not invoke the vulnerable code path.
- **Exploitability:** **CALLED only in test code.** Production sources do not use pytest fixtures. Attack also requires local FS access during a test run by another user — practically inert for CI/dev workflows.

## Commit breakdown (47 commits in 9.0.2…9.0.3)

| Category | Count |
|---|---|
| security/CVE | 1 (`ddee02a` — CVE-2025-71176 backport) |
| breaking | 0 (the 2 keyword hits were doc updates clarifying *already-removed* APIs) |
| bug fixes | 6 (notably: `pytest.approx` mapping key order, `assertrepr_compare` dict order, subtests non-string messages) |
| features | 1 (better string context diff messages) |
| refactor/docs/tests/CI | 39 |

All commits inspected via `gh api repos/pytest-dev/pytest/compare/9.0.2...9.0.3`. None touch public API surfaces consumed by this repo.

## Manifests touched

| File | Change |
|---|---|
| `common/requirements.txt` | `pytest==9.0.2` → `pytest==9.0.3` |
| `libs/requirements.txt` | `pytest==9.0.2` → `pytest==9.0.3` |
| `platform/requirements.txt` | `pytest==9.0.2` → `pytest==9.0.3` |
| `tools/requirements.txt` | `pytest==9.0.2` → `pytest==9.0.3` |
| `dvp/requirements.txt` | `pytest==9.0.2` → `pytest==9.0.3` |

## Build verification

| Phase | Command | Result |
|---|---|---|
| Baseline (pre-change) | `sh bin/build_project.sh -bt` | ✅ pass — 386 + 1 tests, all 5 modules clean |
| Post-change | `sh bin/build_project.sh -bt` | ✅ pass — identical test counts under pytest 9.0.3 |

### Freeze diff (`baseline` vs `post-change`)

```diff
- pytest==9.0.2
+ pytest==9.0.3
```

Only the explicit pin — no transitive dep bumps required.

## Additional automations (pre-push, in same venv)

| Automation | Command | Result |
|---|---|---|
| flake8 lint | `sh bin/build_project.sh -f` | ✅ pass |
| SDK smoke (`dvp init` → `dvp build`) | `sh bin/smoke_plugin_build.sh` | ✅ pass — `artifact.json` 1,167,726 bytes |

## Post-push automations

| Pipeline | Tracking URL | Result |
|---|---|---|
| Delphix blackbox (APPDATA_SDK_UBUNTU20_STAGED_CENTOS73) | https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/217636/ | ⏳ kicked off |

## Source PRs (will auto-close once this merges)

| # | Title |
|---|---|
| #634 | Bump pytest from 9.0.2 to 9.0.3 in /common |
| #635 | Bump pytest from 9.0.2 to 9.0.3 in /dvp |
| #636 | Bump pytest from 9.0.2 to 9.0.3 in /libs |
| #637 | Bump pytest from 9.0.2 to 9.0.3 in /platform |
| #641 | Bump pytest from 9.0.2 to 9.0.3 in /platform |
| #645 | Bump pytest from 9.0.2 to 9.0.3 in /dvp |
| #648 | Bump pytest from 9.0.2 to 9.0.3 in /libs |
| #653 | Bump pytest from 9.0.2 to 9.0.3 in /common |
| #655 | Bump pytest from 9.0.2 to 9.0.3 in /tools |

---

🤖 *Generated by `depbump`. Verification artifacts: baseline-freeze, postchange-freeze, freeze-diff captured locally in the run venv.*
