### PR TITLE
CP-13504 Update docs to mention decorator supports UNIX only and update dvp-api to 1.10.0

### DIFF
--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "dvp-api == 1.10.0.dev3",
+    "dvp-api == 1.10.0",
     "six >= 1.17, < 1.18",
 ]
 

--- a/docs/docs/References/Plugin_Operations.md
+++ b/docs/docs/References/Plugin_Operations.md
@@ -320,6 +320,9 @@ def linked_source_size(direct_source, repository, source_config):
 
 Converts a [Direct Linked Source](Glossary.md#direct-linking) to a physical source. Only applies when a physical export is requested on a dSource using a [Direct Linking](Glossary.md#direct-linking) strategy.
 
+!!! info
+    Can be implemented by any plugin, but the Delphix Engine currently only invokes this operation for UNIX-based environments.
+
 ### Required / Optional
 **Optional.**
 
@@ -739,6 +742,9 @@ def linked_source_size(staged_source, repository, source_config):
 ## Staged Linked Source to Physical
 
 Converts a [Staged Linked Source](Glossary.md#staged-linking) to a physical source. Only applies when a physical export is requested on a dSource using a [Staged Linking](Glossary.md#staged-linking) strategy.
+
+!!! info
+    Can be implemented by any plugin, but the Delphix Engine currently only invokes this operation for UNIX-based environments.
 
 ### Required / Optional
 **Optional.**
@@ -1387,6 +1393,9 @@ def virtual_source_size(virtual_source, repository, source_config):
 ## Virtual Source to Physical
 
 Converts a [Virtual Source](Glossary.md#virtual-source) to a physical source.  Only applies when a physical export is requested on a VDB.
+
+!!! info
+    Can be implemented by any plugin, but the Delphix Engine currently only invokes this operation for UNIX-based environments.
 
 ### Required / Optional
 **Optional.**

--- a/libs/pyproject.toml
+++ b/libs/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 # dvp-common pin is kept in sync with [project].version via .bumpversion.cfg.
 dependencies = [
-    "dvp-api == 1.10.0.dev3",
+    "dvp-api == 1.10.0",
     "dvp-common == 5.1.0",
     "six >= 1.17, < 1.18",
 ]

--- a/platform/pyproject.toml
+++ b/platform/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 # dvp-common pin is kept in sync with [project].version via .bumpversion.cfg.
 dependencies = [
-    "dvp-api == 1.10.0.dev3",
+    "dvp-api == 1.10.0",
     "dvp-common == 5.1.0",
     "six >= 1.17, < 1.18",
 ]


### PR DESCRIPTION
Updating dvp-api version to 1.10.0 (which is released to testpypi) and adding a INFO to decorators for UNIX support only.

#### Automation
- :white_check_mark: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/223293/consoleFull
- :white_check_mark: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/223294/consoleFull
- :white_check_mark: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/223295/consoleFull
- :white_check_mark: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/223296/consoleFull

<img width="849" height="620" alt="Screenshot 2026-07-09 at 2 02 44 PM" src="https://github.com/user-attachments/assets/1de1addd-38fb-48f1-80d2-c997aa7aee11" />
<img width="900" height="533" alt="Screenshot 2026-07-09 at 2 02 29 PM" src="https://github.com/user-attachments/assets/14f6d7d9-dafe-4f5c-a190-6e435e5936a6" />
<img width="905" height="451" alt="Screenshot 2026-07-09 at 2 02 21 PM" src="https://github.com/user-attachments/assets/9cb465ee-d4ff-465b-8414-e4c8f650ca10" />
