### PR TITLE
CP-13545 Update publish docs github action to use latest action versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,10 +23,10 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,10 +23,10 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -29,12 +29,12 @@ jobs:
       # Only a single commit is fetched by default, for the ref/SHA that triggered the workflow.
       # Set fetch-depth: 0 to fetch all history for all branches and tags.
       ###
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -77,7 +77,7 @@ jobs:
           fi
 
       - name: Install Pipenv
-        uses: dschep/install-pipenv-action@v1
+        run: pip install pipenv
 
       - name: Install dependencies for building documenation
         working-directory: ${{ matrix.package }}
@@ -90,7 +90,7 @@ jobs:
       # Docs will be pushed to developer.delphix.com if the repository is delphix/virtualization-sdk.
       - name: Deploy the contents of docs/site to gh-pages (developer.delphix.com) 🚀
         if: ${{ github.repository == matrix.repository }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.SDK_DEPLOY_KEY }}
           publish_dir: docs/site
@@ -101,7 +101,7 @@ jobs:
 
       - name: Deploy the contents of docs/site to personal gh-pages 🚀
         if: ${{ github.repository != matrix.repository }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/site

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -29,12 +29,12 @@ jobs:
       # Only a single commit is fetched by default, for the ref/SHA that triggered the workflow.
       # Set fetch-depth: 0 to fetch all history for all branches and tags.
       ###
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -77,7 +77,7 @@ jobs:
           fi
 
       - name: Install Pipenv
-        run: pip install pipenv
+        run: python -m pip install --upgrade pip pipenv
 
       - name: Install dependencies for building documenation
         working-directory: ${{ matrix.package }}

--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "dvp-api == 1.11.0.dev0",
+    "dvp-api == 1.11.0.dev1",
     "six >= 1.17, < 1.18",
 ]
 

--- a/docs/docs/Versioning_And_Upgrade/Lua_Toolkit_To_SDK_Plugin_Migration/Plugin_Config.md
+++ b/docs/docs/Versioning_And_Upgrade/Lua_Toolkit_To_SDK_Plugin_Migration/Plugin_Config.md
@@ -128,7 +128,7 @@ id: ea009cb4-f76b-46dc-bbb6-689e7acecce4
 name: DelphixDB
 luaName: delphixdb
 minimumLuaVersion: "1.0"
-language: PYTHON27
+language: PYTHON311
 hostTypes:
 - UNIX
 pluginType: STAGED

--- a/libs/pyproject.toml
+++ b/libs/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 # dvp-common pin is kept in sync with [project].version via .bumpversion.cfg.
 dependencies = [
-    "dvp-api == 1.11.0.dev0",
+    "dvp-api == 1.11.0.dev1",
     "dvp-common == 5.2.0",
     "six >= 1.17, < 1.18",
 ]

--- a/platform/pyproject.toml
+++ b/platform/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 # dvp-common pin is kept in sync with [project].version via .bumpversion.cfg.
 dependencies = [
-    "dvp-api == 1.11.0.dev0",
+    "dvp-api == 1.11.0.dev1",
     "dvp-common == 5.2.0",
     "six >= 1.17, < 1.18",
 ]


### PR DESCRIPTION
Updating the github action with new versions and updating the dvp-api to 1.11.0.dev1 with protobuf new version.

Docs changes - https://sumosourabh.github.io/virtualization-sdk/Versioning_And_Upgrade/Lua_Toolkit_To_SDK_Plugin_Migration/Plugin_Config/

New Docs action versions - https://github.com/SumoSourabh/virtualization-sdk/actions/runs/31492336177/job/93781582621